### PR TITLE
Add Parquet tests and documentation for node/edge attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ This CSV would be inserted with the command:
 
 All `storeNum` properties will be inserted as integers, `Location` will be inserted as strings, and `daysOpen` will be inserted as arrays of strings.
 
+## Loading from Parquet files
+
+The bulk loader can also read input directly from Parquet files.
+
+- Parquet files are detected by the `.parquet` extension.
+- Column names in the Parquet schema are treated exactly like CSV headers (for example, `id:ID(User)`, `name:STRING`).
+- All cell values are converted to strings internally, so type inference and `--enforce-schema` work the same way as with CSV.
+- Each Parquet file still represents a single node label or relation type, and multiple attributes are represented by multiple columns, just like in CSV.
+- Reading Parquet requires `pyarrow` to be installed (`pip install pyarrow`).
+- Complex Parquet column types (lists, maps, structs) are stringified; if you rely on arrays or nested structures, make sure their string form matches the CSV conventions described above.
+
+Example (mixing CSV and Parquet inputs):
+
+```sh
+falkordb-bulk-insert StoreGraph \
+  --nodes Store.csv \
+  --nodes StoreExtra.parquet \
+  --relations VISITED.parquet
+```
+
 ## Input Schemas
 
 If the `--enforce-schema` flag is specified, all input CSVs will be expected to specify each column's data type in the header.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ The bulk loader can also read input directly from Parquet files.
   - `age:INT` – integer property.
   - `:START_ID(User)`, `:END_ID(User)` – relation endpoints in the `User` namespace.
 - The physical Parquet types (e.g. `int64`, `double`) are *not* used for schema; only the header text is interpreted. If you want explicit typing, name your Parquet columns using the [Input Schemas](#input-schemas) format.
+- **A schema is not mandatory for Parquet files.** As with CSV, you can either:
+  - rely on the default, schemaless behavior (first column is the node identifier for labels; the first two columns are source and destination IDs for relations), or
+  - enable `--enforce-schema` and use input-schema style headers to control types explicitly.
 - All cell values are converted to strings internally, so type inference and `--enforce-schema` work the same way as with CSV.
 - Each Parquet file still represents a single node label or relation type, and multiple attributes are represented by multiple columns, just like in CSV.
 - Reading Parquet requires `pyarrow` to be installed (`pip install pyarrow`).

--- a/README.md
+++ b/README.md
@@ -145,7 +145,12 @@ All `storeNum` properties will be inserted as integers, `Location` will be inser
 The bulk loader can also read input directly from Parquet files.
 
 - Parquet files are detected by the `.parquet` extension.
-- Column names in the Parquet schema are treated exactly like CSV headers (for example, `id:ID(User)`, `name:STRING`).
+- **Column names in the Parquet schema are treated exactly like CSV headers.** This means you control property types by encoding the type in the column name, for example:
+  - `id:ID(User)` – node identifier of type `ID` in the `User` namespace.
+  - `name:STRING` – string property.
+  - `age:INT` – integer property.
+  - `:START_ID(User)`, `:END_ID(User)` – relation endpoints in the `User` namespace.
+- The physical Parquet types (e.g. `int64`, `double`) are *not* used for schema; only the header text is interpreted. If you want explicit typing, name your Parquet columns using the [Input Schemas](#input-schemas) format.
 - All cell values are converted to strings internally, so type inference and `--enforce-schema` work the same way as with CSV.
 - Each Parquet file still represents a single node label or relation type, and multiple attributes are represented by multiple columns, just like in CSV.
 - Reading Parquet requires `pyarrow` to be installed (`pip install pyarrow`).

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The bulk loader can also read input directly from Parquet files.
 - The physical Parquet types (e.g. `int64`, `double`) are *not* used for schema; only the header text is interpreted. If you want explicit typing, name your Parquet columns using the [Input Schemas](#input-schemas) format.
 - **A schema is not mandatory for Parquet files.** As with CSV, you can either:
   - rely on the default, schemaless behavior (first column is the node identifier for labels; the first two columns are source and destination IDs for relations), or
-  - enable `--enforce-schema` and use input-schema style headers to control types explicitly.
+  - enable `--enforce-schema` and use input-schema-style headers to control types explicitly.
 - All cell values are converted to strings internally, so type inference and `--enforce-schema` work the same way as with CSV.
 - Each Parquet file still represents a single node label or relation type, and multiple attributes are represented by multiple columns, just like in CSV.
 - Reading Parquet requires `pyarrow` to be installed (`pip install pyarrow`).

--- a/falkordb_bulk_loader/bulk_insert.py
+++ b/falkordb_bulk_loader/bulk_insert.py
@@ -5,10 +5,10 @@ import click
 import redis
 from falkordb import FalkorDB
 
-from .config import Config
-from .label import Label
-from .query_buffer import QueryBuffer
-from .relation_type import RelationType
+from falkordb_bulk_loader.config import Config
+from falkordb_bulk_loader.label import Label
+from falkordb_bulk_loader.query_buffer import QueryBuffer
+from falkordb_bulk_loader.relation_type import RelationType
 
 
 def parse_schemas(cls, query_buf, path_to_csv, csv_tuples, config):

--- a/falkordb_bulk_loader/entity_file.py
+++ b/falkordb_bulk_loader/entity_file.py
@@ -213,7 +213,9 @@ class EntityFile(object):
         # Each row should have the same number of fields
         if len(row) != self.column_count:
             location = (
-                f"{self.infile_name}:{line_num}" if line_num is not None else self.infile_name
+                f"{self.infile_name}:{line_num}"
+                if line_num is not None
+                else self.infile_name
             )
             raise CSVError(
                 "%s Expected %d columns, encountered %d ('%s')"

--- a/falkordb_bulk_loader/sources.py
+++ b/falkordb_bulk_loader/sources.py
@@ -1,0 +1,115 @@
+import csv
+import io
+import os
+from typing import Iterable, List
+
+from .exceptions import CSVError
+
+
+class CSVSource:
+    """Tabular source backed by a CSV file.
+
+    Exposes a header row, entity count, and an iterator over data rows.
+    """
+
+    def __init__(self, filename: str, config):
+        self._file = io.open(filename, "rt")
+        self.name = os.path.abspath(filename)
+
+        # Initialize CSV reader that ignores leading whitespace in each field
+        # and does not modify input quote characters.
+        reader = csv.reader(
+            self._file,
+            delimiter=config.separator,
+            skipinitialspace=True,
+            quoting=config.quoting,
+            escapechar=config.escapechar,
+        )
+
+        try:
+            header = next(reader)
+        except StopIteration:
+            raise CSVError(f"{self.name}: Input file is empty")
+
+        self.header: List[str] = header
+        # Count remaining rows (data rows only, excluding header).
+        self.entities_count = sum(1 for _ in reader)
+
+        # Rewind and recreate reader that skips the header row when iterating.
+        self._file.seek(0)
+        self._reader = csv.reader(
+            self._file,
+            delimiter=config.separator,
+            skipinitialspace=True,
+            quoting=config.quoting,
+            escapechar=config.escapechar,
+        )
+        # Skip header
+        next(self._reader, None)
+
+    def iter_rows(self) -> Iterable[List[str]]:
+        for row in self._reader:
+            yield row
+
+    def close(self) -> None:
+        try:
+            self._file.close()
+        except Exception:
+            pass
+
+
+class ParquetSource:
+    """Tabular source backed by a Parquet file.
+
+    Uses pyarrow to read the Parquet file and exposes the same interface
+    as CSVSource. Values are converted to strings (or empty string for NULL)
+    so the existing type inference logic continues to work unchanged.
+    """
+
+    def __init__(self, filename: str, config=None):  # config kept for API symmetry
+        try:
+            import pyarrow.parquet as pq  # type: ignore
+        except ImportError as e:
+            raise RuntimeError(
+                "pyarrow is required to load Parquet files. "
+                "Install it with `pip install pyarrow` or convert your Parquet "
+                "files to CSV."
+            ) from e
+
+        self.name = os.path.abspath(filename)
+        self._table = pq.read_table(filename)
+        self.header: List[str] = list(self._table.column_names)
+        self.entities_count: int = int(self._table.num_rows)
+
+    def iter_rows(self) -> Iterable[List[str]]:
+        # Iterate over record batches to avoid materializing all rows at once.
+        # Note: ``RecordBatch.to_pylist()`` returns a list of dicts mapping
+        # column names to Python values, not a simple list of values.
+        # We must iterate over the columns in ``self.header`` order so that the
+        # row layout matches the header just like CSVSource does.
+        for batch in self._table.to_batches():
+            for row in batch.to_pylist():
+                # ``row`` is a dict {column_name: value}; preserve column order
+                # according to the header and normalize to strings like CSV.
+                values: List[str] = []
+                for col in self.header:
+                    v = row.get(col)
+                    values.append("" if v is None else str(v))
+                yield values
+
+    def close(self) -> None:
+        # Nothing to close explicitly, but drop reference to table.
+        self._table = None
+
+
+def make_source(filename: str, config):
+    """Return an appropriate tabular source for the given file.
+
+    - .parquet -> ParquetSource (requires pyarrow)
+    - otherwise -> CSVSource
+    """
+
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".parquet":
+        return ParquetSource(filename, config)
+    return CSVSource(filename, config)

--- a/falkordb_bulk_loader/sources.py
+++ b/falkordb_bulk_loader/sources.py
@@ -128,7 +128,11 @@ class ParquetSource:
                     yield values
 
         def close(self) -> None:
-            """Release references to the underlying Parquet file object."""
+            """Close the underlying Parquet file object."""
+            try:
+                self._pf.close()
+            except (OSError, AttributeError):
+                pass
             self._pf = None
 
 

--- a/falkordb_bulk_loader/sources.py
+++ b/falkordb_bulk_loader/sources.py
@@ -77,63 +77,66 @@ class CSVSource:
 
 
 class ParquetSource:
-        """Row-oriented tabular source backed by a Parquet file.
+    """Row-oriented tabular source backed by a Parquet file.
 
-        Uses :mod:`pyarrow.parquet` to expose the same interface as
-        :class:`CSVSource`. Values are converted to strings (or the empty
-        string for NULL) so that the existing type inference logic continues
-        to work unchanged.
+    Uses :mod:`pyarrow.parquet` to expose the same interface as
+    :class:`CSVSource`. Values are converted to strings (or the empty
+    string for NULL) so that the existing type inference logic continues
+    to work unchanged.
+    """
+
+    def __init__(self, filename: str, config=None):  # config kept for API symmetry
+        """Open ``filename`` as a Parquet dataset.
+
+        The header and entity count are derived from file metadata so we
+        do not need to materialize the entire file in memory at once.
         """
+        try:
+            import pyarrow.parquet as pq  # type: ignore
+        except ImportError as e:
+            raise RuntimeError(
+                "pyarrow is required to load Parquet files. "
+                "Install it with `pip install pyarrow` or convert your Parquet "
+                "files to CSV."
+            ) from e
 
-        def __init__(self, filename: str, config=None):  # config kept for API symmetry
-            """Open ``filename`` as a Parquet dataset.
+        self.name = os.path.abspath(filename)
+        # Use ParquetFile to avoid reading the entire dataset eagerly.
+        self._pf = pq.ParquetFile(filename)
 
-            The header and entity count are derived from file metadata so we
-            do not need to materialize the entire file in memory at once.
-            """
-            try:
-                import pyarrow.parquet as pq  # type: ignore
-            except ImportError as e:
-                raise RuntimeError(
-                    "pyarrow is required to load Parquet files. "
-                    "Install it with `pip install pyarrow` or convert your Parquet "
-                    "files to CSV."
-                ) from e
+        # Column names and row count come from the schema/metadata.
+        schema = self._pf.schema_arrow
+        self.header = list(schema.names)
+        self.entities_count = int(self._pf.metadata.num_rows)
 
-            self.name = os.path.abspath(filename)
-            # Use ParquetFile to avoid reading the entire dataset eagerly.
-            self._pf = pq.ParquetFile(filename)
+    def iter_rows(self) -> Iterable[List[str]]:
+        """Yield each row as a list of strings in ``self.header`` order.
 
-            # Column names and row count come from the schema/metadata.
-            schema = self._pf.schema_arrow
-            self.header = list(schema.names)
-            self.entities_count = int(self._pf.metadata.num_rows)
+        Iterates over record batches for each row group to keep memory
+        usage bounded for large Parquet files.
+        """
+        # ``iter_batches`` yields RecordBatch instances without
+        # materializing the whole table at once.
+        for batch in self._pf.iter_batches():
+            # ``to_pylist`` on a RecordBatch returns a list of dicts
+            # mapping column names to Python values.
+            for row in batch.to_pylist():
+                values: List[str] = []
+                for col in self.header:
+                    v = row.get(col)
+                    values.append("" if v is None else str(v))
+                yield values
 
-        def iter_rows(self) -> Iterable[List[str]]:
-            """Yield each row as a list of strings in ``self.header`` order.
-
-            Iterates over record batches for each row group to keep memory
-            usage bounded for large Parquet files.
-            """
-            # ``iter_batches`` yields RecordBatch instances without
-            # materializing the whole table at once.
-            for batch in self._pf.iter_batches():
-                # ``to_pylist`` on a RecordBatch returns a list of dicts
-                # mapping column names to Python values.
-                for row in batch.to_pylist():
-                    values: List[str] = []
-                    for col in self.header:
-                        v = row.get(col)
-                        values.append("" if v is None else str(v))
-                    yield values
-
-        def close(self) -> None:
-            """Close the underlying Parquet file object."""
-            try:
-                self._pf.close()
-            except (OSError, AttributeError):
-                pass
-            self._pf = None
+    def close(self) -> None:
+        """Close the underlying Parquet file object."""
+        if self._pf is None:
+            return
+        try:
+            self._pf.close()
+        except OSError:
+            # Non-fatal; we are typically at process teardown.
+            pass
+        self._pf = None
 
 
 def make_source(filename: str, config):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "black>=22.6.0,<27",
     "isort>=8.0.1,<9",
     "flynt>=0.76,<1.1",
+    "pyarrow>=14.0.0",
     # https://github.com/ionrock/cachecontrol/issues/292
     "urllib3==2.6.3",
 ]

--- a/test/test_bulk_loader.py
+++ b/test/test_bulk_loader.py
@@ -365,7 +365,7 @@ class TestBulkLoader:
         with open("/tmp/nodes.tmp", mode="w") as csv_file:
             out = csv.writer(csv_file)
             out.writerow(["id", "nodename"])
-            out.writerow([0])  # Wrong number of properites
+            out.writerow([0])  # Wrong number of properties
 
         runner = CliRunner()
         res = runner.invoke(bulk_insert, ["--nodes", "/tmp/nodes.tmp", graphname])

--- a/test/test_bulk_loader.py
+++ b/test/test_bulk_loader.py
@@ -3,6 +3,7 @@ import os
 import sys
 import unittest
 
+import pytest
 from click.testing import CliRunner
 from falkordb import FalkorDB
 
@@ -937,3 +938,69 @@ class TestBulkLoader:
             [1, "Filipe", ["User"], 1, 40, ["Post"]],
         ]
         assert query_result.result_set == expected_result
+
+
+def test_parquet_bulk_insert(tmp_path):
+    """Verify that the bulk loader can ingest Parquet node and relation files end-to-end."""
+
+    try:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+    except ImportError:
+        pytest.skip("pyarrow is not installed; skipping Parquet bulk loader test")
+
+    # Build a tiny graph in Parquet using the input-schema header style so that
+    # the bulk loader can treat it exactly like a CSV schema.
+    nodes_table = pa.table(
+        {
+            "id:ID(User)": [0, 1],
+            "name:STRING": ["Jeffrey", "Filipe"],
+        }
+    )
+    rels_table = pa.table(
+        {
+            ":START_ID(User)": [0, 1],
+            ":END_ID(User)": [1, 0],
+            "since:INT": [2010, 2015],
+        }
+    )
+
+    nodes_path = tmp_path / "nodes.parquet"
+    rels_path = tmp_path / "relations.parquet"
+    pq.write_table(nodes_table, nodes_path)
+    pq.write_table(rels_table, rels_path)
+
+    graphname = "parquet_graph"
+    runner = CliRunner()
+    res = runner.invoke(
+        bulk_insert,
+        [
+            "--nodes-with-label",
+            "User",
+            str(nodes_path),
+            "--relations-with-type",
+            "KNOWS",
+            str(rels_path),
+            "--enforce-schema",
+            graphname,
+        ],
+        catch_exceptions=False,
+    )
+
+    assert res.exit_code == 0
+    assert "2 nodes created" in res.output
+    assert "2 relations created" in res.output
+
+    db_con = FalkorDB(host="localhost", port=6379)
+    graph = db_con.select_graph(graphname)
+
+    # Verify that nodes and relationships were created correctly.
+    result = graph.query(
+        "MATCH (u:User)-[r:KNOWS]->(v:User) "
+        "RETURN u.id, u.name, r.since, v.id, v.name ORDER BY u.id, v.id"
+    )
+    expected = [
+        ["0", "Jeffrey", 2010, "1", "Filipe"],
+        ["1", "Filipe", 2015, "0", "Jeffrey"],
+    ]
+    assert result.result_set == expected

--- a/test/test_bulk_loader.py
+++ b/test/test_bulk_loader.py
@@ -1004,3 +1004,6 @@ def test_parquet_bulk_insert(tmp_path):
         ["1", "Filipe", 2015, "0", "Jeffrey"],
     ]
     assert result.result_set == expected
+
+    # Clean up the graph created by this test.
+    graph.delete()

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -83,3 +83,33 @@ def test_parquet_label_with_multiple_properties(tmp_path):
     assert label.types[0].name == "ID_STRING"
     assert label.types[1].name == "STRING"
     assert label.types[2].name == "LONG"
+
+
+def test_parquet_label_schemaless_header(tmp_path):
+    """Verify that Parquet label files work without an explicit schema header."""
+    try:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+    except ImportError:
+        pytest.skip("pyarrow is not installed; skipping Parquet tests")
+
+    # No :TYPE suffixes here; this should exercise the same default logic as CSV
+    # (first column is the node identifier, subsequent columns are properties).
+    table = pa.table(
+        {
+            "id": [0, 1],
+            "name": ["Jeff", "Jane"],
+        }
+    )
+    parquet_path = tmp_path / "labels_schemaless.parquet"
+    pq.write_table(table, parquet_path)
+
+    config = Config()  # enforce_schema=False by default
+    label = Label(None, str(parquet_path), "LabelTest", config)
+
+    # First column should be treated as the identifier, second as a property
+    assert label.column_names == ["id", "name"]
+    assert label.column_count == 2
+    assert label.entity_str == "LabelTest"
+    assert label.prop_count == 2
+    assert label.entities_count == 2

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -2,8 +2,11 @@ import csv
 import os
 import unittest
 
+import pytest
+
 from falkordb_bulk_loader.config import Config
 from falkordb_bulk_loader.label import Label
+
 
 class TestBulkLoader:
     @classmethod
@@ -48,3 +51,35 @@ class TestBulkLoader:
         assert label.entities_count == 2
         assert label.types[0].name == "ID_STRING"
         assert label.types[1].name == "STRING"
+
+
+def test_parquet_label_with_multiple_properties(tmp_path):
+    """Verify that Parquet label files with multiple properties are parsed like CSV."""
+    try:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+    except ImportError:
+        pytest.skip("pyarrow is not installed; skipping Parquet tests")
+
+    table = pa.table(
+        {
+            "id:ID(IDNamespace)": [0, 1],
+            "name:STRING": ["Jeff", "Jane"],
+            "age:INT": [30, 40],
+        }
+    )
+    parquet_path = tmp_path / "labels.parquet"
+    pq.write_table(table, parquet_path)
+
+    config = Config(enforce_schema=True, store_node_identifiers=True)
+    label = Label(None, str(parquet_path), "LabelTest", config)
+
+    # Same behavior as CSV header parsing
+    assert label.column_names == ["id", "name", "age"]
+    assert label.column_count == 3
+    assert label.id_namespace == "IDNamespace"
+    assert label.prop_count == 3  # id is exposed as a property when it has a name
+    assert label.entities_count == 2
+    assert label.types[0].name == "ID_STRING"
+    assert label.types[1].name == "STRING"
+    assert label.types[2].name == "LONG"

--- a/test/test_sources.py
+++ b/test/test_sources.py
@@ -1,0 +1,77 @@
+"""Unit tests for falkordb_bulk_loader.sources covering edge-case paths."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from falkordb_bulk_loader.sources import ParquetSource, make_source
+
+
+def test_parquet_source_null_values(tmp_path):
+    """ParquetSource should convert None values to empty strings."""
+    table = pa.table(
+        {
+            "name": ["Alice", None, "Charlie"],
+            "age": [30, 25, None],
+        }
+    )
+    parquet_path = tmp_path / "nulls.parquet"
+    pq.write_table(table, parquet_path)
+
+    src = ParquetSource(str(parquet_path))
+    rows = list(src.iter_rows())
+
+    assert rows[0] == ["Alice", "30"]
+    assert rows[1] == ["", "25"]
+    assert rows[2] == ["Charlie", ""]
+    src.close()
+
+
+def test_parquet_source_close_idempotent(tmp_path):
+    """Calling close() twice should not raise."""
+    table = pa.table({"x": [1]})
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(table, parquet_path)
+
+    src = ParquetSource(str(parquet_path))
+    src.close()
+    # _pf is now None; second close should hit the early-return guard
+    src.close()
+
+
+def test_parquet_source_close_oserror(tmp_path):
+    """An OSError during close() is silently swallowed."""
+    table = pa.table({"x": [1]})
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(table, parquet_path)
+
+    src = ParquetSource(str(parquet_path))
+    # Simulate OSError on close
+    src._pf.close = MagicMock(side_effect=OSError("disk error"))
+    src.close()  # should not raise
+    assert src._pf is None
+
+
+def test_parquet_source_import_error():
+    """ParquetSource raises RuntimeError when pyarrow is unavailable."""
+    # Temporarily hide pyarrow from the import system
+    with patch.dict(sys.modules, {"pyarrow.parquet": None, "pyarrow": None}):
+        with pytest.raises(RuntimeError, match="pyarrow is required"):
+            ParquetSource("/nonexistent.parquet")
+
+
+def test_make_source_parquet(tmp_path):
+    """make_source returns ParquetSource for .parquet files."""
+    table = pa.table({"id": [1, 2]})
+    parquet_path = tmp_path / "nodes.parquet"
+    pq.write_table(table, parquet_path)
+
+    src = make_source(str(parquet_path), None)
+    assert isinstance(src, ParquetSource)
+    assert src.header == ["id"]
+    assert src.entities_count == 2
+    src.close()

--- a/uv.lock
+++ b/uv.lock
@@ -357,7 +357,7 @@ wheels = [
 
 [[package]]
 name = "falkordb-bulk-loader"
-version = "1.0.7"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -372,6 +372,7 @@ dev = [
     { name = "flake8" },
     { name = "flynt" },
     { name = "isort" },
+    { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "typing-extensions" },
@@ -393,6 +394,7 @@ dev = [
     { name = "flake8", specifier = ">=7.3.0,<8" },
     { name = "flynt", specifier = ">=0.76,<1.1" },
     { name = "isort", specifier = ">=8.0.1,<9" },
+    { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "pytest", specifier = ">=9.0.2,<10" },
     { name = "pytest-cov", specifier = ">=2.12.1,<8" },
     { name = "typing-extensions", specifier = ">=4.1.1,<5" },
@@ -561,6 +563,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/d2/281aa3466e948283d51b83238fb456f65e14f8ade5f8627822578cd2708f/ppft-1.7.8.tar.gz", hash = "sha256:5f696d4f397ae9b0af39b1faffb31957c51dfbc5a3815856472d4f4e872937ee", size = 136349, upload-time = "2026-01-19T03:03:13.439Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/e1/d1b380af6443e7c33aeb40617ebdc17c39dc30095235643cc518e3908203/ppft-1.7.8-py3-none-any.whl", hash = "sha256:d3e0e395215b14afc3dd5adfc032ccecfda2d4ed50dc7ded076cd1d215442843", size = 56759, upload-time = "2026-01-19T03:03:11.896Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/bf/a34fee1d624152124fa8355c42f34195ad5fe5233ce5bb87946432047d52/pyarrow-24.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:7c2b98645d576a0b9616892ead22b64a83a5f043c5e2ca15ebcefcb5b70c80cb", size = 35076681, upload-time = "2026-04-21T08:51:46.845Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/41/64180033d7027afce12dc96d0fe1f504c6fa112190582b458acea2399530/pyarrow-24.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:644a246325b8c69c595ad1dd4b463eba4b0cdb731370e4a86137d433208d6147", size = 36684260, upload-time = "2026-04-21T08:51:53.642Z" },
+    { url = "https://files.pythonhosted.org/packages/57/02/9b9320e673dd8a99411fac78690f3df92f6dd6f59754c750110bca66d64e/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:3a577bd840ca83f646f0a625dbc571dba7044c43c2d1503afc378b570954345c", size = 45698566, upload-time = "2026-04-21T10:46:02.133Z" },
+    { url = "https://files.pythonhosted.org/packages/67/33/f75e91b9a64c3f33c787e263c93b871ad91b8a4a68c1d5cebddd9840e835/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e3268e43984d0b1a185c89b4cfff282a7ead12fc93f56cfd7088bdbcbe727041", size = 48835562, upload-time = "2026-04-21T10:46:10.278Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/63/097510448e47e4091faa41c43ba92f97cecaab8f4535b56a3d149578f634/pyarrow-24.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2392d954fcb920f42d230284b677605e4e2fbb11f2821e823e642abd67fbb491", size = 49394997, upload-time = "2026-04-21T10:46:18.08Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6b/c047d6222ab279024a062742d1807e2fbaf27bba88a98637299ff47b9236/pyarrow-24.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bec9373df11544592b0ba7ec2af0e35059e5f0e7647c6183a854dedd193298f1", size = 51911424, upload-time = "2026-04-21T10:46:25.347Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ba/464cc70761c2a525d97ebd84e21c31ebd47f3ef4bdcee117009f51c46f24/pyarrow-24.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:c42ab9439498270139cc63e18847a02afe5c8b3ed9c931266533cfe378bd3591", size = 27251730, upload-time = "2026-04-21T10:46:30.913Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds test coverage for Parquet-based Label and RelationType inputs and clarifies the README around Parquet behavior.
 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parquet (.parquet) input support with automatic source selection and mixed CSV+Parquet handling.

* **Documentation**
  * New "Loading from Parquet files" section; CLI option description fixes and README table/wording corrections.

* **Bug Fixes / UX**
  * Improved file-and-line-aware error messages, consistent row validation, and more reliable progress reporting for tabular inputs.

* **Tests**
  * Added Parquet-parity tests for labels, relations, and end-to-end bulk imports.

* **Chores**
  * Introduced tabular source abstraction and cleaned up import paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 
 
 
 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR extends the bulk loader to support ingesting graph data from Parquet files, providing a more flexible and efficient input option alongside existing CSV support.

#### Key Changes
- Introduced `ParquetSource` for reading `.parquet` files, integrating it with the existing bulk loader logic.
- Refactored `EntityFile` to abstract input file handling, allowing it to work seamlessly with both CSV and Parquet sources.
- Updated `README.md` with comprehensive documentation on using Parquet files, including schema interpretation and examples.
- Added new tests to validate end-to-end Parquet ingestion for nodes and relationships, covering both schemaless and schema-enforced scenarios.
- Improved error reporting by providing more precise file and line number information for validation errors.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 382 (84.3%)   |
| Churn       | 22 (4.9%)     |
| Refactor    | 49 (10.8%)    |
| Total Changes | 453         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>