### PR TITLE
Fix markdown formatting issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Installation by cloning the repository allows the script to be invoked via Pytho
 python3 falkordb_bulk_loader/bulk_insert.py GRAPHNAME [OPTIONS]
 ```
 
-| Flags | Extended flags             | Parameter                                                              |
+|| Flags | Extended flags             | Parameter                                                              |
 |:-----:|----------------------------|:----------------------------------------------------------------------:|
-|  -u   | --redis-url TEXT           | Server url (default: redis://127.0.0 1:6379)                           |
+|  -u   | --redis-url TEXT           | Server URL (default: redis://127.0.0.1:6379)                           |
 |  -n   | --nodes TEXT               | Path to Node CSV file with the filename as the Node Label              |
 |  -N   | --nodes-with-label TEXT    | Node Label followed by path to Node CSV file                           |
 |  -r   | --relations TEXT           | Path to Relationship CSV file with the filename as the Relationship Type  |

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Installation by cloning the repository allows the script to be invoked via Pytho
 python3 falkordb_bulk_loader/bulk_insert.py GRAPHNAME [OPTIONS]
 ```
 
-|| Flags | Extended flags             | Parameter                                                              |
-|:-----:|----------------------------|:----------------------------------------------------------------------:|
+| Flags | Extended flags             | Parameter                                                              |
+|:-----:|----------------------------|------------------------------------------------------------------------|
 |  -u   | --redis-url TEXT           | Server URL (default: redis://127.0.0.1:6379)                           |
 |  -n   | --nodes TEXT               | Path to Node CSV file with the filename as the Node Label              |
 |  -N   | --nodes-with-label TEXT    | Node Label followed by path to Node CSV file                           |
@@ -128,9 +128,9 @@ The flags for `max-token-count`, `max-buffer-size`, and `max-token-size` are typ
 Store.csv
 
 ```csv
-storeNum | Location | daysOpen |
-118 | 123 Main St | ['Mon', 'Wed', 'Fri']
-136 | 55 Elm St | ['Sat', 'Sun']
+storeNum|Location|daysOpen
+118|123 Main St|['Mon', 'Wed', 'Fri']
+136|55 Elm St|['Sat', 'Sun']
 ```
 
 This CSV would be inserted with the command:
@@ -206,17 +206,17 @@ Installation by cloning the repository allows the bulk updater to be invoked via
 python3 falkordb_bulk_loader/bulk_update.py GRAPHNAME [OPTIONS]
 ```
 
-| Flags | Extended flags           |                         Parameter                          |
-|:-----:|--------------------------|:----------------------------------------------------------:|
-|  -h   | --host TEXT              |           Server host (default: 127.0.0.1)                 |
-|  -p   | --port INTEGER           |            Server port (default: 6379)                     |
-|  -a   | --password TEXT          |           Server password (default: none)                  |
-|  -u   | --unix-socket-path TEXT  |           Unix socket path (default: none)                 |
-|  -q   | --query TEXT             |                   Query to run on server                   |
-|  -v   | --variable-name TEXT     |   Variable name for row array in queries (default: row)    |
-|  -c   | --csv TEXT               |                   Path to CSV input file                   |
-|  -o   | --separator TEXT         |             Field token separator in CSV file              |
-|  -n   | --no-header              |             If set, the CSV file has no header             |
+| Flags | Extended flags           | Parameter                                                  |
+|:-----:|--------------------------|------------------------------------------------------------|
+|  -h   | --host TEXT              | Server host (default: 127.0.0.1)                           |
+|  -p   | --port INTEGER           | Server port (default: 6379)                                |
+|  -a   | --password TEXT          | Server password (default: none)                            |
+|  -u   | --unix-socket-path TEXT  | Unix socket path (default: none)                           |
+|  -q   | --query TEXT             | Query to run on server                                     |
+|  -v   | --variable-name TEXT     | Variable name for row array in queries (default: row)      |
+|  -c   | --csv TEXT               | Path to CSV input file                                     |
+|  -o   | --separator TEXT         | Field token separator in CSV file                          |
+|  -n   | --no-header              | If set, the CSV file has no header                         |
 |  -t   | --max-token-size INTEGER | Max size of each token in megabytes (default 500, max 512) |
 
 The bulk updater allows a CSV file to be read in batches and committed to falkordb according to the provided query.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python3 falkordb_bulk_loader/bulk_insert.py GRAPHNAME [OPTIONS]
 |  -b   | --max-buffer-size INT      | (Debug argument) Max batch size (MBs) of each query (default 64)        |
 |  -c   | --max-token-size INT       | (Debug argument) Max size (MBs) of each token sent to the server (default 64) |
 |  -i   | --index Label:Property     | After bulk import, create an Index on provided Label:Property pair (optional) |
-|  -f   | --full-text-index Label:Property | After bulk import, create a full text index on provided Label:Property pair (optional) |
+|  -f   | --full-text-index Label:Property | After bulk import, create a full-text index on provided Label:Property pair (optional) |
 
 The only required arguments are the name to give the newly-created graph (which can appear anywhere) and at least one node CSV file.
 The nodes and relationship flags should be specified once per input file.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python3 falkordb_bulk_loader/bulk_insert.py GRAPHNAME [OPTIONS]
 |  -b   | --max-buffer-size INT      | (Debug argument) Max batch size (MBs) of each query (default 64)        |
 |  -c   | --max-token-size INT       | (Debug argument) Max size (MBs) of each token sent to the server (default 64) |
 |  -i   | --index Label:Property     | After bulk import, create an Index on provided Label:Property pair (optional) |
-|  -f   | --full-text-index Label:Property | After bulk import, create an full text index on provided Label:Property pair (optional) |
+|  -f   | --full-text-index Label:Property | After bulk import, create a full text index on provided Label:Property pair (optional) |
 
 The only required arguments are the name to give the newly-created graph (which can appear anywhere) and at least one node CSV file.
 The nodes and relationship flags should be specified once per input file.


### PR DESCRIPTION
## Summary
Fix markdown formatting issues and typos in README.md. No code changes.

## Changes
- Fixed malformed table header (removed extra leading pipe, removed centered alignment on parameter column)
- Fixed typos: `Server url` → `Server URL`, `127.0.0 1` → `127.0.0.1`, `an full text` → `a full text`
- Standardized CSV example formatting (removed spaces around pipe separators)
- Consistent left-aligned table formatting for both bulk insert and bulk update parameter tables

## Testing
Documentation-only change. No tests needed.

## Memory / Performance Impact
N/A

## Related Issues
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved CLI help text wording and table alignment for clearer presentation of options.
  * Reworded option descriptions for clarity (e.g., full-text index and bulk insert messaging).
  * Reformatted sample CSV to a compact, consistently delimited layout.

* **Bug Fixes**
  * Fixed malformed default server URL formatting in documentation examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->