### PR TITLE
fix(relation_type): use bare `raise` to preserve traceback

### DIFF
--- a/falkordb_bulk_loader/relation_type.py
+++ b/falkordb_bulk_loader/relation_type.py
@@ -73,7 +73,7 @@ class RelationType(EntityFile):
 
                     src = self.query_buffer.nodes[start_id]
                     dest = self.query_buffer.nodes[end_id]
-                except KeyError as e:
+                except KeyError:
                     print(
                         "%s:%d Relationship specified a non-existent identifier. src: %s; dest: %s"
                         % (
@@ -84,7 +84,7 @@ class RelationType(EntityFile):
                         )
                     )
                     if self.config.skip_invalid_edges is False:
-                        raise e
+                        raise
                     continue
                 fmt = "=QQ"  # 8-byte unsigned ints for src and dest
                 try:


### PR DESCRIPTION
## Summary
`raise e` re-raises the caught `KeyError` but drops its original traceback frame. A bare `raise` preserves the full traceback, which is significantly more useful when diagnosing missing-identifier errors during bulk relation loading.

## Changes
- `falkordb_bulk_loader/relation_type.py`: replace `raise e` with bare `raise` and drop the unused `as e` binding to keep flake8 happy.

## Testing
`uv run flake8 falkordb_bulk_loader` clean.

## Memory / Performance Impact
N/A.

## Related Issues
From the comprehensive code-review report (BUG-9).