### PR TITLE
fix(bulk_update): skip empty trailing `emit_buffer` call

### DIFF
--- a/falkordb_bulk_loader/bulk_update.py
+++ b/falkordb_bulk_loader/bulk_update.py
@@ -127,8 +127,9 @@ class BulkUpdate:
                     rows_strs.append(next_line)
                     self.buffer_size += added_size
             # Concatenate all rows into a valid parameter set
-            buf = "".join(["CYPHER rows=[", ",".join(rows_strs), "]"])
-            self.emit_buffer(buf)
+            if rows_strs:
+                buf = "".join(["CYPHER rows=[", ",".join(rows_strs), "]"])
+                self.emit_buffer(buf)
 
 
 ################################################################################

--- a/falkordb_bulk_loader/bulk_update.py
+++ b/falkordb_bulk_loader/bulk_update.py
@@ -157,8 +157,9 @@ class BulkUpdate:
                     rows_strs.append(next_line)
                     self.buffer_size += added_size
             # Concatenate all rows into a valid parameter set
-            buf = "".join(["CYPHER rows=[", ",".join(rows_strs), "]"])
-            self.emit_buffer(buf)
+            if rows_strs:
+                buf = "".join(["CYPHER rows=[", ",".join(rows_strs), "]"])
+                self.emit_buffer(buf)
 
 
 ################################################################################

--- a/test/test_bulk_update.py
+++ b/test/test_bulk_update.py
@@ -2,6 +2,7 @@
 
 import csv
 import os
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -425,22 +426,31 @@ class TestBulkUpdateEmptyCSV:
 
     def test_header_only_csv_does_not_emit(self):
         """emit_buffer must not be called when the CSV contains only a header row."""
-        csv_path = "/tmp/header_only.csv"
-        with open(csv_path, mode="w") as f:
-            f.write("id,name\n")
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False
+        ) as tmp:
+            tmp.write("id,name\n")
+            csv_path = tmp.name
 
-        updater = self._make_updater(csv_path, no_header=False)
-        with patch.object(updater, "emit_buffer") as mock_emit:
-            updater.process_update_csv()
-            mock_emit.assert_not_called()
+        try:
+            updater = self._make_updater(csv_path, no_header=False)
+            with patch.object(updater, "emit_buffer") as mock_emit:
+                updater.process_update_csv()
+                mock_emit.assert_not_called()
+        finally:
+            os.unlink(csv_path)
 
     def test_empty_csv_no_header_does_not_emit(self):
         """emit_buffer must not be called when the CSV is empty and --no-header is set."""
-        csv_path = "/tmp/empty_noheader.csv"
-        with open(csv_path, mode="w") as f:
-            pass  # empty file
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False
+        ) as tmp:
+            csv_path = tmp.name  # empty file
 
-        updater = self._make_updater(csv_path, no_header=True)
-        with patch.object(updater, "emit_buffer") as mock_emit:
-            updater.process_update_csv()
-            mock_emit.assert_not_called()
+        try:
+            updater = self._make_updater(csv_path, no_header=True)
+            with patch.object(updater, "emit_buffer") as mock_emit:
+                updater.process_update_csv()
+                mock_emit.assert_not_called()
+        finally:
+            os.unlink(csv_path)

--- a/test/test_bulk_update.py
+++ b/test/test_bulk_update.py
@@ -3,11 +3,12 @@
 import csv
 import os
 import unittest
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 from falkordb import FalkorDB
 
-from falkordb_bulk_loader.bulk_update import bulk_update
+from falkordb_bulk_loader.bulk_update import BulkUpdate, bulk_update
 
 class TestBulkUpdate:
 
@@ -402,3 +403,44 @@ class TestBulkUpdate:
 
         assert res.exit_code != 0
         assert "No such file" in str(res.exception)
+
+
+class TestBulkUpdateEmptyCSV:
+    """Unit tests for empty-CSV behavior; no live FalkorDB connection needed."""
+
+    def _make_updater(self, csv_path, no_header=False):
+        """Create a BulkUpdate instance backed by a mock client."""
+        mock_client = MagicMock()
+        updater = BulkUpdate(
+            graph_name="testgraph",
+            max_token_size=500,
+            separator=",",
+            no_header=no_header,
+            filename=csv_path,
+            query="CREATE (:L {id: row[0]})",
+            variable_name="row",
+            client=mock_client,
+        )
+        return updater
+
+    def test_header_only_csv_does_not_emit(self):
+        """emit_buffer must not be called when the CSV contains only a header row."""
+        csv_path = "/tmp/header_only.csv"
+        with open(csv_path, mode="w") as f:
+            f.write("id,name\n")
+
+        updater = self._make_updater(csv_path, no_header=False)
+        with patch.object(updater, "emit_buffer") as mock_emit:
+            updater.process_update_csv()
+            mock_emit.assert_not_called()
+
+    def test_empty_csv_no_header_does_not_emit(self):
+        """emit_buffer must not be called when the CSV is empty and --no-header is set."""
+        csv_path = "/tmp/empty_noheader.csv"
+        with open(csv_path, mode="w") as f:
+            pass  # empty file
+
+        updater = self._make_updater(csv_path, no_header=True)
+        with patch.object(updater, "emit_buffer") as mock_emit:
+            updater.process_update_csv()
+            mock_emit.assert_not_called()

--- a/test/test_bulk_update.py
+++ b/test/test_bulk_update.py
@@ -3,6 +3,7 @@
 import csv
 import os
 import sys
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -571,22 +572,31 @@ class TestBulkUpdateEmptyCSV:
 
     def test_header_only_csv_does_not_emit(self):
         """emit_buffer must not be called when the CSV contains only a header row."""
-        csv_path = "/tmp/header_only.csv"
-        with open(csv_path, mode="w") as f:
-            f.write("id,name\n")
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False
+        ) as tmp:
+            tmp.write("id,name\n")
+            csv_path = tmp.name
 
-        updater = self._make_updater(csv_path, no_header=False)
-        with patch.object(updater, "emit_buffer") as mock_emit:
-            updater.process_update_csv()
-            mock_emit.assert_not_called()
+        try:
+            updater = self._make_updater(csv_path, no_header=False)
+            with patch.object(updater, "emit_buffer") as mock_emit:
+                updater.process_update_csv()
+                mock_emit.assert_not_called()
+        finally:
+            os.unlink(csv_path)
 
     def test_empty_csv_no_header_does_not_emit(self):
         """emit_buffer must not be called when the CSV is empty and --no-header is set."""
-        csv_path = "/tmp/empty_noheader.csv"
-        with open(csv_path, mode="w") as f:
-            pass  # empty file
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False
+        ) as tmp:
+            csv_path = tmp.name  # empty file
 
-        updater = self._make_updater(csv_path, no_header=True)
-        with patch.object(updater, "emit_buffer") as mock_emit:
-            updater.process_update_csv()
-            mock_emit.assert_not_called()
+        try:
+            updater = self._make_updater(csv_path, no_header=True)
+            with patch.object(updater, "emit_buffer") as mock_emit:
+                updater.process_update_csv()
+                mock_emit.assert_not_called()
+        finally:
+            os.unlink(csv_path)

--- a/test/test_bulk_update.py
+++ b/test/test_bulk_update.py
@@ -11,7 +11,7 @@ from falkordb import FalkorDB
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import ResponseError
 
-from falkordb_bulk_loader.bulk_update import bulk_update
+from falkordb_bulk_loader.bulk_update import BulkUpdate, bulk_update
 
 
 class TestBulkUpdate:
@@ -550,3 +550,43 @@ class TestBulkUpdate:
             )
 
         assert res.exit_code == 1
+
+class TestBulkUpdateEmptyCSV:
+    """Unit tests for empty-CSV behavior; no live FalkorDB connection needed."""
+
+    def _make_updater(self, csv_path, no_header=False):
+        """Create a BulkUpdate instance backed by a mock client."""
+        mock_client = MagicMock()
+        updater = BulkUpdate(
+            graph_name="testgraph",
+            max_token_size=500,
+            separator=",",
+            no_header=no_header,
+            filename=csv_path,
+            query="CREATE (:L {id: row[0]})",
+            variable_name="row",
+            client=mock_client,
+        )
+        return updater
+
+    def test_header_only_csv_does_not_emit(self):
+        """emit_buffer must not be called when the CSV contains only a header row."""
+        csv_path = "/tmp/header_only.csv"
+        with open(csv_path, mode="w") as f:
+            f.write("id,name\n")
+
+        updater = self._make_updater(csv_path, no_header=False)
+        with patch.object(updater, "emit_buffer") as mock_emit:
+            updater.process_update_csv()
+            mock_emit.assert_not_called()
+
+    def test_empty_csv_no_header_does_not_emit(self):
+        """emit_buffer must not be called when the CSV is empty and --no-header is set."""
+        csv_path = "/tmp/empty_noheader.csv"
+        with open(csv_path, mode="w") as f:
+            pass  # empty file
+
+        updater = self._make_updater(csv_path, no_header=True)
+        with patch.object(updater, "emit_buffer") as mock_emit:
+            updater.process_update_csv()
+            mock_emit.assert_not_called()


### PR DESCRIPTION
## Summary
After the row loop in `process_update_csv`, `emit_buffer` was always called even when `rows_strs` was empty (all rows already flushed in-loop, or no data rows present). This sent a useless `CYPHER rows=[] …` to the server.

## Changes
- `falkordb_bulk_loader/bulk_update.py`: only build and emit the trailing buffer when `rows_strs` is non-empty.

## Testing
`uv run flake8 falkordb_bulk_loader` clean.

## Memory / Performance Impact
Removes one unnecessary network round-trip per update run when the in-loop flush already drained `rows_strs`.

## Related Issues
From the comprehensive code-review report (BUG-15).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the bulk loader would emit unnecessary empty bulk-update commands when processing CSV files with only headers or no data rows.

* **Tests**
  * Added test coverage for edge cases in CSV processing to ensure proper handling of files with headers-only and empty content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->