### PR TITLE
test(bulk_loader): actually assert in `test_utf8` instead of discarding comparison

### DIFF
--- a/test/test_bulk_loader.py
+++ b/test/test_bulk_loader.py
@@ -508,6 +508,7 @@ class TestBulkLoader:
             ["美國人"],
         ]
 
+        assert len(query_result.result_set) == len(expected_strs)
         for i, j in zip(query_result.result_set, expected_strs):
             assert i == j
 

--- a/test/test_bulk_loader.py
+++ b/test/test_bulk_loader.py
@@ -509,7 +509,7 @@ class TestBulkLoader:
         ]
 
         for i, j in zip(query_result.result_set, expected_strs):
-            repr(i) == repr(j)
+            assert i == j
 
     def test_nonstandard_separators(self):
         """Validate use of non-comma delimiters in input files."""


### PR DESCRIPTION
## Summary
The `test_utf8` loop body was `repr(i) == repr(j)` – the comparison's boolean result was discarded, so the test always passed regardless of whether the round-tripped UTF-8 strings matched the expected values.

## Changes
- `test/test_bulk_loader.py`: replace the bare comparison with `assert i == j`. Comparing the values directly (rather than `repr`) is also stricter and friendlier to pytest assertion rewriting.

## Testing
Lint clean. Cannot run the full test suite locally without a FalkorDB server.

## Memory / Performance Impact
N/A.

## Related Issues
From the comprehensive code-review report (BUG-16).