### PR TITLE
fix(bulk_insert): align default --server-url and help text with bulk_update

### DIFF
--- a/falkordb_bulk_loader/bulk_insert.py
+++ b/falkordb_bulk_loader/bulk_insert.py
@@ -52,7 +52,10 @@ def process_entities(entities):
 @click.argument("graph")
 # Server connection settings
 @click.option(
-    "--server-url", "-u", default="redis://127.0.0.1:6379", help="Redis connection url"
+    "--server-url",
+    "-u",
+    default="falkor://127.0.0.1:6379",
+    help="FalkorDB connection url",
 )
 @click.option("--nodes", "-n", multiple=True, help="Path to node csv file")
 @click.option(


### PR DESCRIPTION
## Summary
Both CLI entrypoints now use the same default for `--server-url`:
- `bulk_insert`: `falkor://127.0.0.1:6379` (aligned with `bulk_update`)
- `bulk_update`: `falkor://127.0.0.1:6379` (unchanged)

The help text on `bulk_insert` has also been updated from "Redis connection url" to "FalkorDB connection url" to match `bulk_update`.

This builds on PR #68 which removed the `redis.from_url()` call from `bulk_insert`; that call previously rejected the `falkor://` scheme.

## Changes
- `falkordb_bulk_loader/bulk_insert.py`: change `--server-url` default to `falkor://127.0.0.1:6379` and update help text

## Testing
Existing tests pass. No behaviour change for users who specify `--server-url` explicitly.

## Memory / Performance Impact
N/A.

## Related Issues
From the comprehensive code-review report (BUG-17).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default server connection URL to use the FalkorDB protocol.
  * Clarified the command-line help text to reference FalkorDB connection URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->