### PR TITLE
fix(bulk_update): exclude header row from progress bar entity count

### DIFF
--- a/falkordb_bulk_loader/bulk_update.py
+++ b/falkordb_bulk_loader/bulk_update.py
@@ -90,6 +90,9 @@ class BulkUpdate:
 
     def process_update_csv(self):
         entity_count = count_entities(self.filename)
+        if self.no_header is False:
+            # The header row is counted but not processed as data.
+            entity_count = max(entity_count - 1, 0)
 
         with open(self.filename, "rt") as f:
             if self.no_header is False:


### PR DESCRIPTION
## Summary
`count_entities` returns the total number of lines in the CSV. With the default `--no-header=False`, one line is skipped during processing for the header row, so the progress bar always showed "1 remaining" at the end.

## Changes
- `falkordb_bulk_loader/bulk_update.py`: in `process_update_csv`, subtract 1 from `entity_count` when a header row is expected (clamped at 0 for safety).

## Testing
Lint clean. The progress bar will now reach 100% on completion.

## Memory / Performance Impact
N/A.

## Related Issues
From the comprehensive code-review report (BUG-13).