### PR TITLE
fix(cli): correct and modernise Python version checks

### DIFF
--- a/falkordb_bulk_loader/bulk_insert.py
+++ b/falkordb_bulk_loader/bulk_insert.py
@@ -161,8 +161,8 @@ def bulk_insert(
     index,
     full_text_index,
 ):
-    if sys.version_info.major < 3 or sys.version_info.minor < 6:
-        raise Exception("Python >= 3.6 is required for the falkordb bulk loader.")
+    if sys.version_info < (3, 10):
+        raise RuntimeError("Python >= 3.10 is required for the falkordb bulk loader.")
 
     if not (any(nodes) or any(nodes_with_label)):
         raise Exception("At least one node file must be specified.")

--- a/falkordb_bulk_loader/bulk_update.py
+++ b/falkordb_bulk_loader/bulk_update.py
@@ -181,8 +181,8 @@ def bulk_update(
     no_header,
     max_token_size,
 ):
-    if sys.version_info[0] < 3:
-        raise Exception("Python 3 is required for the falkordb bulk updater.")
+    if sys.version_info < (3, 10):
+        raise RuntimeError("Python >= 3.10 is required for the falkordb bulk updater.")
 
     start_time = timer()
 


### PR DESCRIPTION
## Summary
Two issues with the runtime Python-version checks in the CLIs:

1. `bulk_insert.py` used `sys.version_info.major < 3 or sys.version_info.minor < 6`. The two clauses are not coupled, so e.g. Python 4.0 (`major=4, minor=0`) would falsely fail the check.
2. `pyproject.toml` declares `requires-python = ">=3.10"`, so the check should be for 3.10, not 3.6. `bulk_update.py` only checked for Python 3 at all.

## Changes
- `falkordb_bulk_loader/bulk_insert.py` and `bulk_update.py`: use `sys.version_info < (3, 10)` (tuple comparison) and raise `RuntimeError` with a consistent message.

## Testing
`uv run flake8 falkordb_bulk_loader` clean.

## Memory / Performance Impact
N/A.

## Related Issues
From the comprehensive code-review report (BUG-10).