### PR TITLE
fix(label): raise `CSVError` instead of `sys.exit` on duplicate identifier

### DIFF
--- a/falkordb_bulk_loader/bulk_insert.py
+++ b/falkordb_bulk_loader/bulk_insert.py
@@ -6,6 +6,7 @@ import redis
 from falkordb import FalkorDB
 
 from .config import Config
+from .exceptions import CSVError
 from .label import Label
 from .query_buffer import QueryBuffer
 from .relation_type import RelationType
@@ -223,8 +224,11 @@ def bulk_insert(
         RelationType, query_buf, relations, relations_with_type, config
     )
 
-    process_entities(labels)
-    process_entities(reltypes)
+    try:
+        process_entities(labels)
+        process_entities(reltypes)
+    except CSVError as e:
+        sys.exit(str(e))
 
     # Send all remaining tokens to Redis
     query_buf.send_buffer()

--- a/falkordb_bulk_loader/label.py
+++ b/falkordb_bulk_loader/label.py
@@ -4,7 +4,7 @@ import sys
 import click
 
 from .entity_file import EntityFile, Type
-from .exceptions import SchemaError
+from .exceptions import CSVError, SchemaError
 
 
 class Label(EntityFile):
@@ -57,7 +57,10 @@ class Label(EntityFile):
             )
             sys.stderr.flush()
             if self.config.skip_invalid_nodes is False:
-                sys.exit(1)
+                raise CSVError(
+                    "Duplicate node identifier '%s' at %s:%d"
+                    % (identifier, self.infile.name, self.reader.line_num)
+                )
         self.query_buffer.nodes[identifier] = self.query_buffer.top_node_id
         self.query_buffer.top_node_id += 1
 


### PR DESCRIPTION
## Summary
`Label.update_node_dictionary` called `sys.exit(1)` when it encountered a duplicate node identifier and `--skip-invalid-nodes` was not set. `sys.exit` from a library function raises `SystemExit` (a `BaseException`), which is awkward for callers to catch and makes unit testing more difficult.

## Changes
- `falkordb_bulk_loader/label.py`: raise `CSVError` with a descriptive "Duplicate node identifier '<id>' at <file>:<line>" message instead of `sys.exit(1)`.
- Add `CSVError` to the existing `from .exceptions import …` line.

## Testing
Lint clean. CLI behaviour is preserved: an unhandled `CSVError` still terminates the process with a non-zero exit code, and the same descriptive line is also written to stderr (existing message unchanged).

## Memory / Performance Impact
N/A.

## Related Issues
From the comprehensive code-review report (BUG-11). Note: this PR addresses BUG-11 only; the related BUG-1 (the duplicate-node row is also still inserted, corrupting the ID mapping when `skip_invalid_nodes=True`) is handled separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for CSV validation and parsing failures with improved error messaging
  * Improved detection and reporting of duplicate node identifier errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->