### PR TITLE
fix(entity_file): emit clear error when schema header field has no type

### DIFF
--- a/falkordb_bulk_loader/entity_file.py
+++ b/falkordb_bulk_loader/entity_file.py
@@ -265,6 +265,13 @@ class EntityFile(object):
                     f"{self.infile.name}: Field '{field}' had {len(field)} colons"
                 )
 
+            # No colon found - the schema header is missing a type for this field.
+            if len(pair) < 2:
+                raise CSVError(
+                    f"{self.infile.name}: Schema header field '{field}' is missing "
+                    f"a type (expected 'name:TYPE')"
+                )
+
             # Convert the column type.
             col_type = convert_schema_type(pair[1].upper().strip())
 

--- a/falkordb_bulk_loader/entity_file.py
+++ b/falkordb_bulk_loader/entity_file.py
@@ -292,7 +292,7 @@ class EntityFile(object):
             # Missing colon means the field is not a valid name:type pair.
             if len(pair) < 2:
                 raise CSVError(
-                    f"{self.infile.name}: Field '{field}' is missing a colon separator"
+                    f"{self.infile.name}: Field '{field}' is missing a type (expected 'name:TYPE')"
                 )
 
             # Convert the column type.

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -2,7 +2,10 @@ import csv
 import os
 import unittest
 
+import pytest
+
 from falkordb_bulk_loader.config import Config
+from falkordb_bulk_loader.exceptions import CSVError
 from falkordb_bulk_loader.label import Label
 
 class TestBulkLoader:
@@ -48,3 +51,14 @@ class TestBulkLoader:
         assert label.entities_count == 2
         assert label.types[0].name == "ID_STRING"
         assert label.types[1].name == "STRING"
+
+    def test_schema_header_field_missing_type_raises(self):
+        """Verify that a schema header field without a type raises a clear CSVError."""
+        with open("/tmp/labels.tmp", mode="w") as csv_file:
+            out = csv.writer(csv_file)
+            out.writerow(["id:ID", "name"])  # 'name' has no type
+            out.writerow([0, "Alice"])
+
+        config = Config(enforce_schema=True)
+        with pytest.raises(CSVError, match="missing a type"):
+            Label(None, "/tmp/labels.tmp", "LabelTest", config)


### PR DESCRIPTION
## Summary
In schema mode, `convert_header_with_schema` split each header field on `:` and immediately indexed `pair[1]`. If a field contained no colon (e.g. `name` instead of `name:STRING`), this raised an opaque `IndexError: list index out of range` instead of a helpful schema validation error.

## Changes
- `falkordb_bulk_loader/entity_file.py`: detect `len(pair) < 2` after the existing `len(pair) > 2` check and raise a descriptive `CSVError` ("Schema header field '<field>' is missing a type (expected 'name:TYPE')").

## Testing
`uv run flake8 falkordb_bulk_loader` clean.

## Memory / Performance Impact
N/A.

## Related Issues
From the comprehensive code-review report (BUG-4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed array values with clearer schema errors.
  * Added specific validation messages for invalid integer and `LONG` values.
  * Added support for UTF-8 BOMs in input files.
  * Improved entity counting for CSV data containing embedded line breaks.
  * Clarified errors when schema types are missing, including the expected format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->