### PR TITLE
fix(bulk_insert): drop redundant `redis_con`; reuse `client.connection`

### DIFF
--- a/falkordb_bulk_loader/bulk_insert.py
+++ b/falkordb_bulk_loader/bulk_insert.py
@@ -198,8 +198,8 @@ def bulk_insert(
 
     # Attempt to verify that falkordb module is loaded
     try:
-        module_list = [m[b"name"] for m in client.connection.module_list()]
-        if b"graph" not in module_list:
+        module_list = [m["name"] for m in client.connection.module_list()]
+        if "graph" not in module_list:
             print("falkordb module not loaded on connected server.")
             sys.exit(1)
     except redis.exceptions.ResponseError:

--- a/falkordb_bulk_loader/bulk_insert.py
+++ b/falkordb_bulk_loader/bulk_insert.py
@@ -187,19 +187,18 @@ def bulk_insert(
         escapechar,
     )
 
-    redis_con = redis.from_url(server_url)
     client = FalkorDB.from_url(server_url)
 
     # Attempt to connect to the server
     try:
-        redis_con.ping()
+        client.connection.ping()
     except redis.exceptions.ConnectionError as e:
         print("Could not connect to FalkorDB server.")
         raise e
 
     # Attempt to verify that falkordb module is loaded
     try:
-        module_list = [m[b"name"] for m in redis_con.module_list()]
+        module_list = [m[b"name"] for m in client.connection.module_list()]
         if b"graph" not in module_list:
             print("falkordb module not loaded on connected server.")
             sys.exit(1)
@@ -208,7 +207,7 @@ def bulk_insert(
         pass
 
     # Verify that the graph name is not already used in the Redis database
-    key_exists = redis_con.exists(graph)
+    key_exists = client.connection.exists(graph)
     if key_exists:
         print(
             f"Graph with name '{graph}', could not be created, as '{graph}' already exists."


### PR DESCRIPTION
## Summary
`bulk_insert` opened two separate connections to the same server:
- `redis_con = redis.from_url(server_url)` – used only for `ping`, `module_list` and `exists`.
- `client = FalkorDB.from_url(server_url)` – used for everything else.

The first connection is never explicitly released and accomplishes nothing the FalkorDB client cannot do via `client.connection`. Route the startup checks through `client.connection` to match the pattern already used by `bulk_update` and avoid leaving a dangling connection in the redis-py connection pool.

## Changes
- `falkordb_bulk_loader/bulk_insert.py`: replace `redis_con.ping()`, `redis_con.module_list()`, and `redis_con.exists(graph)` with the equivalent `client.connection.*` calls. Remove the now-unused `redis_con` variable.

## Testing
`uv run flake8 falkordb_bulk_loader` clean.

## Memory / Performance Impact
Removes one redundant connection per CLI invocation.

## Related Issues
From the comprehensive code-review report (BUG-18).