### PR TITLE
fix(csv): open input files as `utf-8-sig` to strip BOM transparently

### DIFF
--- a/falkordb_bulk_loader/bulk_update.py
+++ b/falkordb_bulk_loader/bulk_update.py
@@ -14,7 +14,7 @@ def utf8len(s):
 # Count number of rows in file.
 def count_entities(filename):
     entities_count = 0
-    with open(filename, "rt") as f:
+    with open(filename, "rt", encoding="utf-8-sig") as f:
         entities_count = sum(1 for line in f)
     return entities_count
 
@@ -91,7 +91,7 @@ class BulkUpdate:
     def process_update_csv(self):
         entity_count = count_entities(self.filename)
 
-        with open(self.filename, "rt") as f:
+        with open(self.filename, "rt", encoding="utf-8-sig") as f:
             if self.no_header is False:
                 next(f)  # skip header
 

--- a/falkordb_bulk_loader/entity_file.py
+++ b/falkordb_bulk_loader/entity_file.py
@@ -189,7 +189,9 @@ class EntityFile(object):
         else:
             self.entity_str = os.path.splitext(os.path.basename(filename))[0]
         # Input file handling
-        self.infile = io.open(filename, "rt")
+        # Use utf-8-sig so a leading BOM (common in Excel exports) is stripped
+        # transparently; falls back to standard UTF-8 otherwise.
+        self.infile = io.open(filename, "rt", encoding="utf-8-sig")
 
         # Initialize CSV reader that ignores leading whitespace in each field
         # and does not modify input quote characters


### PR DESCRIPTION
## Summary
The CSV input files were opened without an explicit encoding (`io.open(filename, "rt")` / `open(filename, "rt")`), so on Windows the system ANSI codepage was used and UTF-8-with-BOM files (the default for Excel "Save as CSV (UTF-8)") had `\ufeff` prepended to the first column name. This silently broke:
- schema-mode header parsing (the first `name:TYPE` field was now `\ufeffname:TYPE`),
- the "underscore-prefix means non-property ID" heuristic in `Label.process_schemaless_header`,
- the column-name → property mapping for the affected first column generally.

## Changes
Use `encoding="utf-8-sig"` everywhere a CSV is opened. `utf-8-sig` transparently strips a leading BOM if present and behaves like plain `utf-8` otherwise.
- `falkordb_bulk_loader/entity_file.py`: `EntityFile.__init__` opens `self.infile` with `encoding="utf-8-sig"`.
- `falkordb_bulk_loader/bulk_update.py`: same for `count_entities` and `process_update_csv`.

## Testing
Lint clean (`flake8`, `black`).

## Memory / Performance Impact
Negligible; `utf-8-sig` only adds a single optional 3-byte BOM check at file open.

## Related Issues
From the comprehensive code-review report (BUG-6).