### PR TITLE
fix(entity_file): translate array-literal parse errors to `SchemaError`

### DIFF
--- a/falkordb_bulk_loader/entity_file.py
+++ b/falkordb_bulk_loader/entity_file.py
@@ -49,7 +49,15 @@ def convert_schema_type(in_type):
 def array_prop_to_binary(format_str, prop_val):
     # Evaluate the array to convert its elements.
     # (This allows us to handle nested arrays.)
-    array_val = ast.literal_eval(prop_val)
+    # Catch ValueError/SyntaxError (malformed input) and RecursionError/
+    # MemoryError (pathological deep nesting) explicitly so callers get a
+    # clear SchemaError instead of an opaque interpreter-level exception.
+    try:
+        array_val = ast.literal_eval(prop_val)
+    except (ValueError, SyntaxError, RecursionError, MemoryError) as e:
+        raise SchemaError(
+            f"Could not parse '{prop_val}' as an array: {type(e).__name__}"
+        )
     # Send array length as a long.
     array_to_send = struct.pack(format_str + "q", Type.ARRAY.value, len(array_val))
     # Recursively send each array element as a string.

--- a/falkordb_bulk_loader/entity_file.py
+++ b/falkordb_bulk_loader/entity_file.py
@@ -172,7 +172,9 @@ def inferred_prop_to_binary(prop_val):
     if prop_val[0] == "[" and prop_val[-1] == "]":
         try:
             return array_prop_to_binary(format_str, prop_val)
-        except Exception:
+        except SchemaError:
+            # Schemaless mode: if the value looks like an array but can't be
+            # parsed, fall through and treat it as a plain string.
             pass
 
     # If we've reached this point, the property is a string.

--- a/test/test_entity_file.py
+++ b/test/test_entity_file.py
@@ -1,0 +1,101 @@
+"""Unit tests for entity_file helper functions."""
+
+import pytest
+
+from falkordb_bulk_loader.entity_file import (
+    array_prop_to_binary,
+    inferred_prop_to_binary,
+    typed_prop_to_binary,
+    Type,
+)
+from falkordb_bulk_loader.exceptions import SchemaError
+
+
+class TestArrayPropToBinary:
+    """Tests for array_prop_to_binary covering the new SchemaError guard."""
+
+    FORMAT = "=B"
+
+    def test_valid_array(self):
+        """A well-formed array literal returns bytes without raising."""
+        result = array_prop_to_binary(self.FORMAT, "[1, 2, 3]")
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_malformed_array_raises_schema_error(self):
+        """A syntactically invalid array raises SchemaError (not ValueError/SyntaxError)."""
+        with pytest.raises(SchemaError) as exc_info:
+            array_prop_to_binary(self.FORMAT, "[not valid python]")
+        assert "Could not parse" in str(exc_info.value)
+        assert "SyntaxError" in str(exc_info.value) or "ValueError" in str(exc_info.value)
+
+    def test_deeply_nested_array_raises_schema_error(self):
+        """A deeply nested literal (RecursionError path) raises SchemaError."""
+        deep = "[" * 5000 + "]" * 5000
+        with pytest.raises(SchemaError) as exc_info:
+            array_prop_to_binary(self.FORMAT, deep)
+        assert "Could not parse" in str(exc_info.value)
+
+    def test_schema_error_message_contains_type_name(self):
+        """The SchemaError message includes the originating exception type name."""
+        with pytest.raises(SchemaError) as exc_info:
+            array_prop_to_binary(self.FORMAT, "[1, 2,")  # truncated → SyntaxError
+        error_msg = str(exc_info.value)
+        assert "SyntaxError" in error_msg or "ValueError" in error_msg
+
+
+class TestInferredPropToBinary:
+    """Tests for inferred_prop_to_binary schemaless fall-through behaviour."""
+
+    def test_valid_array_parsed_as_array(self):
+        """A well-formed array literal is returned as an ARRAY binary blob."""
+        result = inferred_prop_to_binary("[1, 2]")
+        # First byte is the type enum; ARRAY == 5
+        assert result[0] == Type.ARRAY.value
+
+    def test_malformed_array_falls_through_to_string(self):
+        """A bracket-enclosed value that can't be parsed as an array becomes a string."""
+        result = inferred_prop_to_binary("[not valid python]")
+        # First byte should be STRING == 3, not ARRAY == 5
+        assert result[0] == Type.STRING.value
+
+    def test_plain_string(self):
+        """A plain string is returned as a STRING binary blob."""
+        result = inferred_prop_to_binary("hello")
+        assert result[0] == Type.STRING.value
+
+    def test_integer(self):
+        """An integer string is returned as a LONG binary blob."""
+        result = inferred_prop_to_binary("42")
+        assert result[0] == Type.LONG.value
+
+    def test_float(self):
+        """A float string is returned as a DOUBLE binary blob."""
+        result = inferred_prop_to_binary("3.14")
+        assert result[0] == Type.DOUBLE.value
+
+    def test_bool_true(self):
+        """The string 'true' is returned as a BOOL binary blob."""
+        result = inferred_prop_to_binary("true")
+        assert result[0] == Type.BOOL.value
+
+    def test_bool_false(self):
+        """The string 'false' is returned as a BOOL binary blob."""
+        result = inferred_prop_to_binary("false")
+        assert result[0] == Type.BOOL.value
+
+
+class TestTypedPropToBinary:
+    """Tests for typed_prop_to_binary ensuring SchemaError propagates in schema mode."""
+
+    def test_malformed_array_raises_schema_error_in_typed_mode(self):
+        """A malformed array in schema-enforced ARRAY column raises SchemaError."""
+        with pytest.raises(SchemaError) as exc_info:
+            typed_prop_to_binary("[not valid", Type.ARRAY)
+        assert "Could not parse" in str(exc_info.value)
+
+    def test_valid_array_in_typed_mode(self):
+        """A valid array in schema-enforced ARRAY column returns bytes."""
+        result = typed_prop_to_binary("[1, 2, 3]", Type.ARRAY)
+        assert isinstance(result, bytes)
+        assert result[0] == Type.ARRAY.value


### PR DESCRIPTION
## Summary
`array_prop_to_binary` called `ast.literal_eval(prop_val)` with no exception handling. Three problem cases:

- `ValueError` / `SyntaxError` from malformed array literals leaked out as opaque tracebacks.
- `RecursionError` from deeply nested input (e.g. `[[[[[…]]]]]` thousands of levels deep) bypassed the schema-error path entirely.
- `MemoryError` from huge literal sets did the same.

In schema mode (`typed_prop_to_binary`) these errors are not caught further up either, so the bulk loader aborted with a Python traceback instead of a useful schema-validation message.

## Changes
- `falkordb_bulk_loader/entity_file.py`: wrap the `ast.literal_eval` call in `array_prop_to_binary` to catch `ValueError`, `SyntaxError`, `RecursionError`, `MemoryError` and re-raise as `SchemaError` with the original exception type name in the message.

## Testing
`uv run flake8 falkordb_bulk_loader` clean. The change preserves the success path; only the error path is more user-friendly.

## Memory / Performance Impact
N/A on the success path; deeply-nested inputs now fail fast with a clear message instead of consuming stack/memory until the interpreter raises.

## Related Issues
From the comprehensive code-review report (BUG-19).