### PR TITLE
fix(loader): always close CSV file handle on exception via try/finally

### DIFF
--- a/falkordb_bulk_loader/label.py
+++ b/falkordb_bulk_loader/label.py
@@ -87,7 +87,7 @@ class Label(EntityFile):
                         raise SchemaError(
                             "%s:%d %s"
                             % (self.infile.name, self.reader.line_num - 1, str(e))
-                        )
+                        ) from e
                     row_binary_len = len(row_binary)
                     # If the addition of this entity will make the binary token grow too large,
                     # send the buffer now.
@@ -110,5 +110,8 @@ class Label(EntityFile):
                     self.binary_entities.append(row_binary)
                 self.query_buffer.labels.append(self.to_binary())
         finally:
-            self.infile.close()
+            try:
+                self.infile.close()
+            except OSError:
+                pass
         print("%d nodes created with label '%s'" % (entities_created, self.entity_str))

--- a/falkordb_bulk_loader/label.py
+++ b/falkordb_bulk_loader/label.py
@@ -63,50 +63,52 @@ class Label(EntityFile):
 
     def process_entities(self):
         entities_created = 0
-        with click.progressbar(
-            self.reader,
-            length=self.entities_count,
-            label=self.entity_str,
-            update_min_steps=100,
-        ) as reader:
-            for row in reader:
-                self.validate_row(row)
+        try:
+            with click.progressbar(
+                self.reader,
+                length=self.entities_count,
+                label=self.entity_str,
+                update_min_steps=100,
+            ) as reader:
+                for row in reader:
+                    self.validate_row(row)
 
-                # Update the node identifier dictionary if necessary
-                if self.config.store_node_identifiers:
-                    id_field = row[self.id]
-                    if self.id_namespace is not None:
-                        id_field = self.id_namespace + "." + str(id_field)
-                    self.update_node_dictionary(id_field)
+                    # Update the node identifier dictionary if necessary
+                    if self.config.store_node_identifiers:
+                        id_field = row[self.id]
+                        if self.id_namespace is not None:
+                            id_field = self.id_namespace + "." + str(id_field)
+                        self.update_node_dictionary(id_field)
 
-                try:
-                    row_binary = self.pack_props(row)
-                except SchemaError as e:
-                    # TODO why is line_num off by one?
-                    raise SchemaError(
-                        "%s:%d %s"
-                        % (self.infile.name, self.reader.line_num - 1, str(e))
-                    )
-                row_binary_len = len(row_binary)
-                # If the addition of this entity will make the binary token grow too large,
-                # send the buffer now.
-                # TODO how much of this can be made uniform w/ relations and moved to Querybuffer?
-                added_size = self.binary_size + row_binary_len
-                if (
-                    added_size >= self.config.max_token_size
-                    or self.query_buffer.buffer_size + added_size
-                    >= self.config.max_buffer_size
-                ):
-                    self.query_buffer.labels.append(self.to_binary())
-                    self.query_buffer.send_buffer()
-                    self.reset_partial_binary()
-                    # Push the label onto the query buffer again, as there are more entities to process.
-                    self.query_buffer.labels.append(self.to_binary())
+                    try:
+                        row_binary = self.pack_props(row)
+                    except SchemaError as e:
+                        # TODO why is line_num off by one?
+                        raise SchemaError(
+                            "%s:%d %s"
+                            % (self.infile.name, self.reader.line_num - 1, str(e))
+                        )
+                    row_binary_len = len(row_binary)
+                    # If the addition of this entity will make the binary token grow too large,
+                    # send the buffer now.
+                    # TODO how much of this can be made uniform w/ relations and moved to Querybuffer?
+                    added_size = self.binary_size + row_binary_len
+                    if (
+                        added_size >= self.config.max_token_size
+                        or self.query_buffer.buffer_size + added_size
+                        >= self.config.max_buffer_size
+                    ):
+                        self.query_buffer.labels.append(self.to_binary())
+                        self.query_buffer.send_buffer()
+                        self.reset_partial_binary()
+                        # Push the label onto the query buffer again, as there are more entities to process.
+                        self.query_buffer.labels.append(self.to_binary())
 
-                self.query_buffer.node_count += 1
-                entities_created += 1
-                self.binary_size += row_binary_len
-                self.binary_entities.append(row_binary)
-            self.query_buffer.labels.append(self.to_binary())
-        self.infile.close()
+                    self.query_buffer.node_count += 1
+                    entities_created += 1
+                    self.binary_size += row_binary_len
+                    self.binary_entities.append(row_binary)
+                self.query_buffer.labels.append(self.to_binary())
+        finally:
+            self.infile.close()
         print("%d nodes created with label '%s'" % (entities_created, self.entity_str))

--- a/falkordb_bulk_loader/label.py
+++ b/falkordb_bulk_loader/label.py
@@ -112,6 +112,10 @@ class Label(EntityFile):
         finally:
             try:
                 self.infile.close()
-            except OSError:
-                pass
+            except OSError as e:
+                # Closing the input file is best-effort during cleanup; do not fail processing on close errors.
+                sys.stderr.write(
+                    "Warning: failed to close file '%s': %s\n" % (self.infile.name, str(e))
+                )
+                sys.stderr.flush()
         print("%d nodes created with label '%s'" % (entities_created, self.entity_str))

--- a/falkordb_bulk_loader/label.py
+++ b/falkordb_bulk_loader/label.py
@@ -73,66 +73,71 @@ class Label(EntityFile):
         return True
 
     def process_entities(self):
-        entities_created = 0
-        logger.debug(
-            f"Processing node file '{self.infile.name}' "
-            f"with label '{self.entity_str}' ({self.entities_count} entities)..."
-        )
-        with click.progressbar(
-            self.reader,
-            length=self.entities_count,
-            label=self.entity_str,
-            update_min_steps=100,
-        ) as reader:
-            for row in reader:
-                self.validate_row(row)
+        try:
+            entities_created = 0
+            logger.debug(
+                f"Processing node file '{self.infile.name}' "
+                f"with label '{self.entity_str}' ({self.entities_count} entities)..."
+            )
+            with click.progressbar(
+                self.reader,
+                length=self.entities_count,
+                label=self.entity_str,
+                update_min_steps=100,
+            ) as reader:
+                for row in reader:
+                    self.validate_row(row)
 
-                # Update the node identifier dictionary if necessary
-                if self.config.store_node_identifiers:
-                    id_field = row[self.id]
-                    if self.id_namespace is not None:
-                        id_field = self.id_namespace + "." + str(id_field)
-                    if not self.update_node_dictionary(id_field):
-                        # Duplicate identifier and skip_invalid_nodes is True;
-                        # truly skip this row so we do not corrupt the ID
-                        # mapping or insert the duplicate into the graph.
-                        continue
+                    # Update the node identifier dictionary if necessary
+                    if self.config.store_node_identifiers:
+                        id_field = row[self.id]
+                        if self.id_namespace is not None:
+                            id_field = self.id_namespace + "." + str(id_field)
+                        if not self.update_node_dictionary(id_field):
+                            # Duplicate identifier and skip_invalid_nodes is True;
+                            # truly skip this row so we do not corrupt the ID
+                            # mapping or insert the duplicate into the graph.
+                            continue
 
-                try:
-                    row_binary = self.pack_props(row)
-                except SchemaError as e:
-                    # TODO why is line_num off by one?
-                    raise SchemaError(
-                        "%s:%d %s"
-                        % (self.infile.name, self.reader.line_num - 1, str(e))
-                    )
-                row_binary_len = len(row_binary)
-                # If the addition of this entity will make the binary token grow too large,
-                # send the buffer now.
-                # TODO how much of this can be made uniform w/ relations and moved to Querybuffer?
-                added_size = self.binary_size + row_binary_len
-                if (
-                    added_size >= self.config.max_token_size
-                    or self.query_buffer.buffer_size + added_size
-                    >= self.config.max_buffer_size
-                ):
-                    logger.debug(
-                        "Buffer size threshold reached while processing '%s' "
-                        "(label '%s'); flushing partial buffer."
-                        % (self.infile.name, self.entity_str)
-                    )
-                    self.query_buffer.labels.append(self.to_binary())
-                    self.query_buffer.send_buffer()
-                    self.reset_partial_binary()
-                    # Push the label onto the query buffer again, as there are more entities to process.
-                    self.query_buffer.labels.append(self.to_binary())
+                    try:
+                        row_binary = self.pack_props(row)
+                    except SchemaError as e:
+                        # TODO why is line_num off by one?
+                        raise SchemaError(
+                            "%s:%d %s"
+                            % (self.infile.name, self.reader.line_num - 1, str(e))
+                        )
+                    row_binary_len = len(row_binary)
+                    # If the addition of this entity will make the binary token grow too large,
+                    # send the buffer now.
+                    # TODO how much of this can be made uniform w/ relations and moved to Querybuffer?
+                    added_size = self.binary_size + row_binary_len
+                    if (
+                        added_size >= self.config.max_token_size
+                        or self.query_buffer.buffer_size + added_size
+                        >= self.config.max_buffer_size
+                    ):
+                        logger.debug(
+                            "Buffer size threshold reached while processing '%s' "
+                            "(label '%s'); flushing partial buffer."
+                            % (self.infile.name, self.entity_str)
+                        )
+                        self.query_buffer.labels.append(self.to_binary())
+                        self.query_buffer.send_buffer()
+                        self.reset_partial_binary()
+                        # Push the label onto the query buffer again, as there are more entities to process.
+                        self.query_buffer.labels.append(self.to_binary())
 
-                self.query_buffer.node_count += 1
-                entities_created += 1
-                self.binary_size += row_binary_len
-                self.binary_entities.append(row_binary)
-            self.query_buffer.labels.append(self.to_binary())
-        self.infile.close()
-        logger.info(
-            "%d nodes created with label '%s'" % (entities_created, self.entity_str)
-        )
+                    self.query_buffer.node_count += 1
+                    entities_created += 1
+                    self.binary_size += row_binary_len
+                    self.binary_entities.append(row_binary)
+                self.query_buffer.labels.append(self.to_binary())
+            logger.info(
+                "%d nodes created with label '%s'" % (entities_created, self.entity_str)
+            )
+        finally:
+            try:
+                self.infile.close()
+            except Exception as e:
+                logger.warning("Failed to close input file cleanly: %s", e)

--- a/falkordb_bulk_loader/relation_type.py
+++ b/falkordb_bulk_loader/relation_type.py
@@ -55,65 +55,68 @@ class RelationType(EntityFile):
 
     def process_entities(self):
         entities_created = 0
-        with click.progressbar(
-            self.reader,
-            length=self.entities_count,
-            label=self.entity_str,
-            update_min_steps=100,
-        ) as reader:
-            for row in reader:
-                self.validate_row(row)
-                try:
-                    start_id = row[self.start_id]
-                    if self.start_namespace:
-                        start_id = self.start_namespace + "." + str(start_id)
-                    end_id = row[self.end_id]
-                    if self.end_namespace:
-                        end_id = self.end_namespace + "." + str(end_id)
+        try:
+            with click.progressbar(
+                self.reader,
+                length=self.entities_count,
+                label=self.entity_str,
+                update_min_steps=100,
+            ) as reader:
+                for row in reader:
+                    self.validate_row(row)
+                    try:
+                        start_id = row[self.start_id]
+                        if self.start_namespace:
+                            start_id = self.start_namespace + "." + str(start_id)
+                        end_id = row[self.end_id]
+                        if self.end_namespace:
+                            end_id = self.end_namespace + "." + str(end_id)
 
-                    src = self.query_buffer.nodes[start_id]
-                    dest = self.query_buffer.nodes[end_id]
-                except KeyError as e:
-                    print(
-                        "%s:%d Relationship specified a non-existent identifier. src: %s; dest: %s"
-                        % (
-                            self.infile.name,
-                            self.reader.line_num - 1,
-                            row[self.start_id],
-                            row[self.end_id],
+                        src = self.query_buffer.nodes[start_id]
+                        dest = self.query_buffer.nodes[end_id]
+                    except KeyError as e:
+                        print(
+                            "%s:%d Relationship specified a non-existent identifier. src: %s; dest: %s"
+                            % (
+                                self.infile.name,
+                                self.reader.line_num - 1,
+                                row[self.start_id],
+                                row[self.end_id],
+                            )
                         )
-                    )
-                    if self.config.skip_invalid_edges is False:
-                        raise e
-                    continue
-                fmt = "=QQ"  # 8-byte unsigned ints for src and dest
-                try:
-                    row_binary = struct.pack(fmt, src, dest) + self.pack_props(row)
-                except SchemaError as e:
-                    raise SchemaError(
-                        "%s:%d %s" % (self.infile.name, self.reader.line_num, str(e))
-                    )
-                row_binary_len = len(row_binary)
-                # If the addition of this entity will make the binary token grow too large,
-                # send the buffer now.
-                added_size = self.binary_size + row_binary_len
-                if (
-                    added_size >= self.config.max_token_size
-                    or self.query_buffer.buffer_size + added_size
-                    >= self.config.max_buffer_size
-                ):
-                    self.query_buffer.reltypes.append(self.to_binary())
-                    self.query_buffer.send_buffer()
-                    self.reset_partial_binary()
-                    # Push the reltype onto the query buffer again, as there are more entities to process.
-                    self.query_buffer.reltypes.append(self.to_binary())
+                        if self.config.skip_invalid_edges is False:
+                            raise e
+                        continue
+                    fmt = "=QQ"  # 8-byte unsigned ints for src and dest
+                    try:
+                        row_binary = struct.pack(fmt, src, dest) + self.pack_props(row)
+                    except SchemaError as e:
+                        raise SchemaError(
+                            "%s:%d %s"
+                            % (self.infile.name, self.reader.line_num, str(e))
+                        )
+                    row_binary_len = len(row_binary)
+                    # If the addition of this entity will make the binary token grow too large,
+                    # send the buffer now.
+                    added_size = self.binary_size + row_binary_len
+                    if (
+                        added_size >= self.config.max_token_size
+                        or self.query_buffer.buffer_size + added_size
+                        >= self.config.max_buffer_size
+                    ):
+                        self.query_buffer.reltypes.append(self.to_binary())
+                        self.query_buffer.send_buffer()
+                        self.reset_partial_binary()
+                        # Push the reltype onto the query buffer again, as there are more entities to process.
+                        self.query_buffer.reltypes.append(self.to_binary())
 
-                self.query_buffer.relation_count += 1
-                entities_created += 1
-                self.binary_size += row_binary_len
-                self.binary_entities.append(row_binary)
-            self.query_buffer.reltypes.append(self.to_binary())
-        self.infile.close()
+                    self.query_buffer.relation_count += 1
+                    entities_created += 1
+                    self.binary_size += row_binary_len
+                    self.binary_entities.append(row_binary)
+                self.query_buffer.reltypes.append(self.to_binary())
+        finally:
+            self.infile.close()
         print(
             "%d relations created for type '%s'" % (entities_created, self.entity_str)
         )

--- a/falkordb_bulk_loader/relation_type.py
+++ b/falkordb_bulk_loader/relation_type.py
@@ -119,6 +119,7 @@ class RelationType(EntityFile):
             try:
                 self.infile.close()
             except OSError:
+                # Best-effort cleanup: ignore close errors because processing is complete.
                 pass
         print(
             "%d relations created for type '%s'" % (entities_created, self.entity_str)

--- a/falkordb_bulk_loader/relation_type.py
+++ b/falkordb_bulk_loader/relation_type.py
@@ -94,7 +94,7 @@ class RelationType(EntityFile):
                         raise SchemaError(
                             "%s:%d %s"
                             % (self.infile.name, self.reader.line_num, str(e))
-                        )
+                        ) from e
                     row_binary_len = len(row_binary)
                     # If the addition of this entity will make the binary token grow too large,
                     # send the buffer now.
@@ -116,7 +116,10 @@ class RelationType(EntityFile):
                     self.binary_entities.append(row_binary)
                 self.query_buffer.reltypes.append(self.to_binary())
         finally:
-            self.infile.close()
+            try:
+                self.infile.close()
+            except OSError:
+                pass
         print(
             "%d relations created for type '%s'" % (entities_created, self.entity_str)
         )

--- a/falkordb_bulk_loader/relation_type.py
+++ b/falkordb_bulk_loader/relation_type.py
@@ -57,75 +57,80 @@ class RelationType(EntityFile):
             self.end_namespace = end_match.group(1)
 
     def process_entities(self):
-        entities_created = 0
-        logger.debug(
-            f"Processing relation file '{self.infile.name}' "
-            f"with type '{self.entity_str}' ({self.entities_count} entities)..."
-        )
-        with click.progressbar(
-            self.reader,
-            length=self.entities_count,
-            label=self.entity_str,
-            update_min_steps=100,
-        ) as reader:
-            for row in reader:
-                self.validate_row(row)
-                try:
-                    start_id = row[self.start_id]
-                    if self.start_namespace:
-                        start_id = self.start_namespace + "." + str(start_id)
-                    end_id = row[self.end_id]
-                    if self.end_namespace:
-                        end_id = self.end_namespace + "." + str(end_id)
+        try:
+            entities_created = 0
+            logger.debug(
+                f"Processing relation file '{self.infile.name}' "
+                f"with type '{self.entity_str}' ({self.entities_count} entities)..."
+            )
+            with click.progressbar(
+                self.reader,
+                length=self.entities_count,
+                label=self.entity_str,
+                update_min_steps=100,
+            ) as reader:
+                for row in reader:
+                    self.validate_row(row)
+                    try:
+                        start_id = row[self.start_id]
+                        if self.start_namespace:
+                            start_id = self.start_namespace + "." + str(start_id)
+                        end_id = row[self.end_id]
+                        if self.end_namespace:
+                            end_id = self.end_namespace + "." + str(end_id)
 
-                    src = self.query_buffer.nodes[start_id]
-                    dest = self.query_buffer.nodes[end_id]
-                except KeyError:
-                    logger.error(
-                        "%s:%d Relationship specified a non-existent identifier. src: %s; dest: %s"
-                        % (
-                            self.infile.name,
-                            self.reader.line_num - 1,
-                            row[self.start_id],
-                            row[self.end_id],
+                        src = self.query_buffer.nodes[start_id]
+                        dest = self.query_buffer.nodes[end_id]
+                    except KeyError:
+                        logger.error(
+                            "%s:%d Relationship specified a non-existent identifier. src: %s; dest: %s"
+                            % (
+                                self.infile.name,
+                                self.reader.line_num - 1,
+                                row[self.start_id],
+                                row[self.end_id],
+                            )
                         )
-                    )
-                    if self.config.skip_invalid_edges is False:
-                        raise
-                    continue
-                fmt = "=QQ"  # 8-byte unsigned ints for src and dest
-                try:
-                    row_binary = struct.pack(fmt, src, dest) + self.pack_props(row)
-                except SchemaError as e:
-                    raise SchemaError(
-                        "%s:%d %s" % (self.infile.name, self.reader.line_num, str(e))
-                    )
-                row_binary_len = len(row_binary)
-                # If the addition of this entity will make the binary token grow too large,
-                # send the buffer now.
-                added_size = self.binary_size + row_binary_len
-                if (
-                    added_size >= self.config.max_token_size
-                    or self.query_buffer.buffer_size + added_size
-                    >= self.config.max_buffer_size
-                ):
-                    logger.debug(
-                        "Buffer size threshold reached while processing '%s' "
-                        "(relation type '%s'); flushing partial buffer."
-                        % (self.infile.name, self.entity_str)
-                    )
-                    self.query_buffer.reltypes.append(self.to_binary())
-                    self.query_buffer.send_buffer()
-                    self.reset_partial_binary()
-                    # Push the reltype onto the query buffer again, as there are more entities to process.
-                    self.query_buffer.reltypes.append(self.to_binary())
+                        if self.config.skip_invalid_edges is False:
+                            raise
+                        continue
+                    fmt = "=QQ"  # 8-byte unsigned ints for src and dest
+                    try:
+                        row_binary = struct.pack(fmt, src, dest) + self.pack_props(row)
+                    except SchemaError as e:
+                        raise SchemaError(
+                            "%s:%d %s" % (self.infile.name, self.reader.line_num, str(e))
+                        )
+                    row_binary_len = len(row_binary)
+                    # If the addition of this entity will make the binary token grow too large,
+                    # send the buffer now.
+                    added_size = self.binary_size + row_binary_len
+                    if (
+                        added_size >= self.config.max_token_size
+                        or self.query_buffer.buffer_size + added_size
+                        >= self.config.max_buffer_size
+                    ):
+                        logger.debug(
+                            "Buffer size threshold reached while processing '%s' "
+                            "(relation type '%s'); flushing partial buffer."
+                            % (self.infile.name, self.entity_str)
+                        )
+                        self.query_buffer.reltypes.append(self.to_binary())
+                        self.query_buffer.send_buffer()
+                        self.reset_partial_binary()
+                        # Push the reltype onto the query buffer again, as there are more entities to process.
+                        self.query_buffer.reltypes.append(self.to_binary())
 
-                self.query_buffer.relation_count += 1
-                entities_created += 1
-                self.binary_size += row_binary_len
-                self.binary_entities.append(row_binary)
-            self.query_buffer.reltypes.append(self.to_binary())
-        self.infile.close()
-        logger.info(
-            "%d relations created for type '%s'" % (entities_created, self.entity_str)
-        )
+                    self.query_buffer.relation_count += 1
+                    entities_created += 1
+                    self.binary_size += row_binary_len
+                    self.binary_entities.append(row_binary)
+                self.query_buffer.reltypes.append(self.to_binary())
+            logger.info(
+                "%d relations created for type '%s'" % (entities_created, self.entity_str)
+            )
+        finally:
+            try:
+                self.infile.close()
+            except Exception as e:
+                logger.warning("Failed to close input file cleanly: %s", e)

--- a/falkordb_bulk_loader/relation_type.py
+++ b/falkordb_bulk_loader/relation_type.py
@@ -99,7 +99,8 @@ class RelationType(EntityFile):
                         row_binary = struct.pack(fmt, src, dest) + self.pack_props(row)
                     except SchemaError as e:
                         raise SchemaError(
-                            "%s:%d %s" % (self.infile.name, self.reader.line_num, str(e))
+                            "%s:%d %s"
+                            % (self.infile.name, self.reader.line_num, str(e))
                         )
                     row_binary_len = len(row_binary)
                     # If the addition of this entity will make the binary token grow too large,
@@ -127,7 +128,8 @@ class RelationType(EntityFile):
                     self.binary_entities.append(row_binary)
                 self.query_buffer.reltypes.append(self.to_binary())
             logger.info(
-                "%d relations created for type '%s'" % (entities_created, self.entity_str)
+                "%d relations created for type '%s'"
+                % (entities_created, self.entity_str)
             )
         finally:
             try:


### PR DESCRIPTION
## Summary
`Label.process_entities` and `RelationType.process_entities` opened the CSV file in their constructors and closed it manually at the end of `process_entities`. Any exception during processing (`SchemaError`, `KeyError` for missing edge endpoints when `skip_invalid_edges=False`, network failures from `send_buffer`, etc.) skipped the `close()` call and leaked the file descriptor.

## Changes
- `falkordb_bulk_loader/label.py` and `falkordb_bulk_loader/relation_type.py`: wrap the processing block in `try/finally` so `self.infile.close()` always runs.

## Testing
`uv run flake8` / `uv run black --target-version py310 --check` clean.

## Memory / Performance Impact
Eliminates a file-descriptor leak on the error path. Success path is unaffected.

## Related Issues
From the comprehensive code-review report (BUG-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved resource cleanup and error handling to ensure input files are properly closed even when processing errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->