### PR TITLE
Grant id-token permission for PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # Required for PyPI Trusted Publishing (OIDC)
 
 jobs:
   deploy:


### PR DESCRIPTION
Added permission for id-token to enable OIDC for PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release infrastructure to enhance security and reliability of the package publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->