### PR TITLE
feat: support multi-file bulk-update with per-file queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ python3 falkordb_bulk_loader/bulk_insert.py GRAPHNAME [OPTIONS]
 
 The only required arguments are the name to give the newly-created graph (which can appear anywhere) and at least one node CSV file.
 The nodes and relationship flags should be specified once per input file.
+When both are provided, all node files are loaded before any relationship files.
 
 ```sh
 falkordb-bulk-insert GRAPH_DEMO -n example/Person.csv -n example/Country.csv -r example/KNOWS.csv -r example/VISITED.csv
@@ -213,20 +214,46 @@ python3 falkordb_bulk_loader/bulk_update.py GRAPHNAME [OPTIONS]
 |       | --socket-timeout FLOAT   | Socket read/write timeout in seconds                        |
 |       | --socket-connect-timeout FLOAT | Socket connection timeout in seconds                 |
 |  -q   | --query TEXT             | Query to run on server                                     |
+|       | --query-file TEXT        | CSV with per-file query mappings: `input_file,query`      |
 |  -v   | --variable-name TEXT     | Variable name for row array in queries (default: row)      |
 |  -c   | --csv TEXT               | Path to CSV input file                                     |
+|       | --nodes TEXT             | Node input file. Can be specified multiple times.          |
+|       | --relations TEXT         | Relation input file. Can be specified multiple times.      |
 |  -o   | --separator TEXT         | Field token separator in CSV file                          |
 |  -n   | --no-header              | If set, the CSV file has no header                         |
 |  -t   | --max-token-size INTEGER | Max size of each token in megabytes (default 500, max 512) |
 |       | --verbose                | Print extra information about the steps performed during the update |
 
-The bulk updater allows a CSV file to be read in batches and committed to falkordb according to the provided query. Use `--socket-timeout` and `--socket-connect-timeout` to tune client socket deadlines for long-running updates.
+The bulk updater supports:
+- Single-file mode: `--csv` + `--query`.
+- Multi-file mode: `--nodes` / `--relations` + `--query-file`.
+- Timeout tuning: `--socket-timeout` and `--socket-connect-timeout`.
+
+In multi-file mode, all `--nodes` inputs are processed first, followed by all `--relations` inputs.
+
+The bulk updater reads input file(s) in batches and commits changes according to each provided query.
 
 For example, given the CSV files described in [Input Schema CSV examples](#input-schema-csv-examples), the bulk loader could create the same nodes and relationships with the commands:
 
 ```sh
 falkordb-bulk-update SocialGraph --csv User.csv --query "MERGE (:User {id: row[0], name: row[1], rank: row[2]})"
 falkordb-bulk-update SocialGraph --csv FOLLOWS.csv --query "MATCH (start {id: row[0]}), (end {id: row[1]}) MERGE (start)-[f:FOLLOWS]->(end) SET f.reaction_count = row[2]"
+```
+
+Or as a single multi-file update run:
+
+`queries.csv`:
+
+```csv
+User.csv,"MERGE (:User {id: row[0], name: row[1], rank: row[2]})"
+FOLLOWS.csv,"MATCH (start {id: row[0]}), (end {id: row[1]}) MERGE (start)-[f:FOLLOWS]->(end) SET f.reaction_count = row[2]"
+```
+
+```sh
+falkordb-bulk-update SocialGraph \
+  --nodes User.csv \
+  --relations FOLLOWS.csv \
+  --query-file queries.csv
 ```
 
 When using the bulk updater, it is essential to sanitize CSV inputs beforehand, as falkordb *will* commit changes to the graph incrementally. As such, malformed inputs may leave the graph in a partially-updated state.

--- a/falkordb_bulk_loader/bulk_update.py
+++ b/falkordb_bulk_loader/bulk_update.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import os
 import sys
 from timeit import default_timer as timer
 
@@ -14,6 +15,89 @@ logger = logging.getLogger(__name__)
 
 def utf8len(s):
     return len(s.encode("utf-8"))
+
+
+def parse_query_file(query_file):
+    query_map = {}
+    with open(query_file, "rt") as f:
+        reader = csv.reader(f)
+        for line_num, row in enumerate(reader, start=1):
+            if len(row) < 2:
+                raise click.ClickException(
+                    f"{query_file}:{line_num} expected 2 columns: input file, query"
+                )
+
+            input_file = row[0].strip()
+            query = ",".join(row[1:]).strip()
+            if input_file == "" or query == "":
+                raise click.ClickException(
+                    f"{query_file}:{line_num} expected non-empty input file and query"
+                )
+
+            if input_file in query_map:
+                raise click.ClickException(
+                    f"{query_file}:{line_num} duplicate query mapping for '{input_file}'"
+                )
+            query_map[input_file] = query
+
+    if len(query_map) == 0:
+        raise click.ClickException(f"{query_file} did not include any query mappings")
+    return query_map
+
+
+def query_for_input_file(input_file, query_map):
+    # Allow mappings by original argument, absolute path, or basename.
+    candidates = [input_file, os.path.abspath(input_file), os.path.basename(input_file)]
+    queries = [
+        query_map[candidate] for candidate in candidates if candidate in query_map
+    ]
+
+    if len(queries) == 0:
+        raise click.ClickException(
+            f"No query mapping found for input file '{input_file}'. "
+            "Add a matching row in --query-file."
+        )
+
+    if len(set(queries)) > 1:
+        raise click.ClickException(
+            f"Ambiguous query mapping for '{input_file}'. "
+            "Use a single unambiguous key in --query-file."
+        )
+    return queries[0]
+
+
+def collect_jobs(csv_file, query, nodes, relations, query_file):
+    using_single_file_mode = bool(csv_file or query)
+    using_multi_file_mode = bool(any(nodes) or any(relations) or query_file)
+
+    if using_single_file_mode and using_multi_file_mode:
+        raise click.ClickException(
+            "Do not combine --csv/--query with --nodes/--relations/--query-file."
+        )
+
+    if using_multi_file_mode:
+        if not query_file:
+            raise click.ClickException(
+                "--query-file is required when using --nodes/--relations."
+            )
+        if not (any(nodes) or any(relations)):
+            raise click.ClickException(
+                "At least one input file is required via --nodes or --relations."
+            )
+
+        query_map = parse_query_file(query_file)
+        jobs = []
+
+        # Enforce node files first, then relation files.
+        for node_file in nodes:
+            jobs.append((node_file, query_for_input_file(node_file, query_map)))
+        for relation_file in relations:
+            jobs.append((relation_file, query_for_input_file(relation_file, query_map)))
+        return jobs
+
+    if not csv_file or not query:
+        raise click.ClickException("Single-file mode requires both --csv and --query.")
+    return [(csv_file, query)]
 
 
 # Count number of rows in file.
@@ -170,13 +254,28 @@ class BulkUpdate:
 # Cypher query options
 @click.option("--query", "-q", help="Query to run on server")
 @click.option(
+    "--query-file",
+    help="Path to CSV mapping input files to per-file queries. "
+    "Each row must be: input_file,query",
+)
+@click.option(
     "--variable-name",
     "-v",
     default="row",
     help="Variable name for row array in queries (default: row)",
 )
 # CSV file options
-@click.option("--csv", "-c", help="Path to CSV input file")
+@click.option("--csv", "-c", "csv_file", help="Path to CSV input file")
+@click.option(
+    "--nodes",
+    multiple=True,
+    help="Path to node input file (processed before relations when using --query-file)",
+)
+@click.option(
+    "--relations",
+    multiple=True,
+    help="Path to relation input file (processed after nodes when using --query-file)",
+)
 @click.option(
     "--separator", "-o", default=",", help="Field token separator in CSV file"
 )
@@ -206,8 +305,11 @@ def bulk_update(
     socket_timeout,
     socket_connect_timeout,
     query,
+    query_file,
     variable_name,
-    csv,
+    csv_file,
+    nodes,
+    relations,
     separator,
     no_header,
     max_token_size,
@@ -256,35 +358,61 @@ def bulk_update(
             "Server does not support 'MODULE LIST'; skipping FalkorDB module check."
         )
 
-    updater = BulkUpdate(
-        graph,
-        max_token_size,
-        separator,
-        no_header,
-        csv,
-        query,
-        variable_name,
-        client,
-    )
+    jobs = collect_jobs(csv_file, query, nodes, relations, query_file)
 
     logger.debug(f"Validating query against graph '{graph}'...")
 
     if graph in client.list_graphs():
-        updater.validate_query()
+        for filename, file_query in jobs:
+            updater = BulkUpdate(
+                graph,
+                max_token_size,
+                separator,
+                no_header,
+                filename,
+                file_query,
+                variable_name,
+                client,
+            )
+            updater.validate_query()
     else:
         g = client.select_graph(graph)
         # create the graph
         g.query("RETURN 1")
-        updater.validate_query()
+        for filename, file_query in jobs:
+            updater = BulkUpdate(
+                graph,
+                max_token_size,
+                separator,
+                no_header,
+                filename,
+                file_query,
+                variable_name,
+                client,
+            )
+            updater.validate_query()
         g.delete()
 
-    logger.debug(f"Processing CSV file '{csv}'...")
-
-    updater.process_update_csv()
+    statistics = {}
+    for filename, file_query in jobs:
+        logger.debug(f"Processing CSV file '{filename}'...")
+        updater = BulkUpdate(
+            graph,
+            max_token_size,
+            separator,
+            no_header,
+            filename,
+            file_query,
+            variable_name,
+            client,
+        )
+        updater.process_update_csv()
+        for key, value in updater.statistics.items():
+            statistics[key] = statistics.get(key, 0) + value
 
     end_time = timer()
 
-    for key, value in updater.statistics.items():
+    for key, value in statistics.items():
         logger.info(key + ": " + repr(value))
     logger.info(
         f"Update of graph '{graph}' complete in {end_time - start_time:f} seconds"

--- a/test/test_bulk_update.py
+++ b/test/test_bulk_update.py
@@ -383,6 +383,115 @@ class TestBulkUpdate:
         assert res.exit_code != 0
         assert "'undefined_identifier' not defined" in str(res.exception)
 
+    def test_query_file_multi_csv_nodes_then_relations(self):
+        """Validate per-file query mappings and node-first processing in multi-file mode."""
+        graphname = "query_file_multi_csv"
+        users_file = "/tmp/users_update.tmp"
+        devices_file = "/tmp/devices_update.tmp"
+        owns_file = "/tmp/owns_update.tmp"
+        query_file = "/tmp/query_map.tmp"
+
+        with open(users_file, mode="w") as csv_file:
+            out = csv.writer(csv_file)
+            out.writerow(["id", "name"])
+            out.writerow([0, "u0"])
+            out.writerow([1, "u1"])
+
+        with open(devices_file, mode="w") as csv_file:
+            out = csv.writer(csv_file)
+            out.writerow(["id", "model"])
+            out.writerow([10, "d10"])
+            out.writerow([11, "d11"])
+
+        with open(owns_file, mode="w") as csv_file:
+            out = csv.writer(csv_file)
+            out.writerow(["user_id", "device_id"])
+            out.writerow([0, 10])
+            out.writerow([1, 11])
+
+        with open(query_file, mode="w") as csv_file:
+            out = csv.writer(csv_file)
+            out.writerow(
+                [
+                    "users_update.tmp",
+                    "MERGE (:User {id: toInteger(row[0]), name: row[1]})",
+                ]
+            )
+            out.writerow(
+                [
+                    "devices_update.tmp",
+                    "MERGE (:Device {id: toInteger(row[0]), model: row[1]})",
+                ]
+            )
+            out.writerow(
+                [
+                    "owns_update.tmp",
+                    "MATCH (u:User {id: toInteger(row[0])}), "
+                    "(d:Device {id: toInteger(row[1])}) "
+                    "MERGE (u)-[:OWNS]->(d)",
+                ]
+            )
+
+        runner = CliRunner()
+        res = runner.invoke(
+            bulk_update,
+            [
+                "--nodes",
+                users_file,
+                "--nodes",
+                devices_file,
+                "--relations",
+                owns_file,
+                "--query-file",
+                query_file,
+                graphname,
+            ],
+            catch_exceptions=False,
+        )
+
+        assert res.exit_code == 0
+        assert "Nodes created: 4" in res.output
+        assert "Relationships created: 2" in res.output
+
+        tmp_graph = self.db_con.select_graph(graphname)
+        query_result = tmp_graph.query(
+            "MATCH (u:User)-[:OWNS]->(d:Device) RETURN u.id, d.id ORDER BY u.id"
+        )
+        expected_result = [[0, 10], [1, 11]]
+        assert query_result.result_set == expected_result
+
+    def test_query_file_missing_mapping(self):
+        """Validate that each declared input file requires a query mapping."""
+        graphname = "missing_query_mapping"
+        nodes_file = "/tmp/nodes_missing_query.tmp"
+        query_file = "/tmp/missing_query_map.tmp"
+
+        with open(nodes_file, mode="w") as csv_file:
+            out = csv.writer(csv_file)
+            out.writerow(["id", "name"])
+            out.writerow([0, "u0"])
+
+        with open(query_file, mode="w") as csv_file:
+            out = csv.writer(csv_file)
+            out.writerow(
+                ["some_other_file.csv", "MERGE (:User {id: toInteger(row[0])})"]
+            )
+
+        runner = CliRunner()
+        res = runner.invoke(
+            bulk_update,
+            [
+                "--nodes",
+                nodes_file,
+                "--query-file",
+                query_file,
+                graphname,
+            ],
+        )
+
+        assert res.exit_code != 0
+        assert "No query mapping found for input file" in res.output
+
     def test_invalid_inputs(self):
         """Validate that the bulk updater handles invalid inputs incorrectly."""
         graphname = "tmpgraph6"
@@ -411,15 +520,9 @@ class TestBulkUpdate:
         fake_client.connection.module_list.return_value = [{"name": "graph"}]
         fake_client.list_graphs.return_value = [graphname]
 
-        # Provide a dummy updater so bulk_update can finish without a real CSV.
-        fake_updater = MagicMock()
-        fake_updater.statistics = {}
-
         runner = CliRunner()
         with (
-            patch(
-                "falkordb_bulk_loader.bulk_update.BulkUpdate", return_value=fake_updater
-            ),
+            patch("falkordb_bulk_loader.bulk_update.collect_jobs", return_value=[]),
             patch(
                 "falkordb_bulk_loader.bulk_update.FalkorDB.from_url",
                 return_value=fake_client,
@@ -428,10 +531,6 @@ class TestBulkUpdate:
             res = runner.invoke(
                 bulk_update,
                 [
-                    "--csv",
-                    "/tmp/csv.tmp",
-                    "--query",
-                    "CREATE (:L {id: row[0]})",
                     "--socket-timeout",
                     "300",
                     "--socket-connect-timeout",
@@ -477,13 +576,7 @@ class TestBulkUpdate:
         ):
             res = runner.invoke(
                 bulk_update,
-                [
-                    "--csv",
-                    "/tmp/csv.tmp",
-                    "--query",
-                    "CREATE (:L {id: row[0]})",
-                    graphname,
-                ],
+                [graphname],
             )
 
         assert res.exit_code != 0
@@ -499,14 +592,9 @@ class TestBulkUpdate:
         )
         fake_client.list_graphs.return_value = [graphname]
 
-        fake_updater = MagicMock()
-        fake_updater.statistics = {}
-
         runner = CliRunner()
         with (
-            patch(
-                "falkordb_bulk_loader.bulk_update.BulkUpdate", return_value=fake_updater
-            ),
+            patch("falkordb_bulk_loader.bulk_update.collect_jobs", return_value=[]),
             patch(
                 "falkordb_bulk_loader.bulk_update.FalkorDB.from_url",
                 return_value=fake_client,
@@ -514,13 +602,7 @@ class TestBulkUpdate:
         ):
             res = runner.invoke(
                 bulk_update,
-                [
-                    "--csv",
-                    "/tmp/csv.tmp",
-                    "--query",
-                    "CREATE (:L {id: row[0]})",
-                    graphname,
-                ],
+                [graphname],
                 catch_exceptions=False,
             )
 
@@ -540,13 +622,7 @@ class TestBulkUpdate:
         ):
             res = runner.invoke(
                 bulk_update,
-                [
-                    "--csv",
-                    "/tmp/csv.tmp",
-                    "--query",
-                    "CREATE (:L {id: row[0]})",
-                    graphname,
-                ],
+                [graphname],
             )
 
         assert res.exit_code == 1


### PR DESCRIPTION
## Summary
- Add multi-file bulk-update mode via `--nodes` / `--relations` plus `--query-file` per-file Cypher mappings.
- Process node files before relation files and aggregate statistics across jobs.
- Document multi-file usage and add tests for happy-path and missing-mapping errors.

## Depends on
Stacked on #112 (socket timeout tuning). Once #112 merges, retarget this PR to `master`.

## Test plan
- [x] Local formatting (`black`, `isort`)
- [ ] CI lint + tests on this PR