### PR TITLE
fix(entity_file): support POSIX named pipes (FIFOs) and non-seekable streams

### DIFF
--- a/falkordb_bulk_loader/entity_file.py
+++ b/falkordb_bulk_loader/entity_file.py
@@ -3,6 +3,7 @@ import csv
 import io
 import math
 import os
+import stat
 import struct
 import sys
 from enum import Enum
@@ -225,21 +226,34 @@ class EntityFile(object):
 
     # Count number of rows in file.
     def count_entities(self):
-        # Open a separate file handle so self.reader's position and line_num
-        # are not disturbed.  Using csv.reader (rather than raw line iteration)
-        # ensures that fields containing embedded newlines (RFC 4180) are
-        # counted as a single row.
-        with io.open(self.infile.name, "rt") as counting_file:
-            counting_reader = csv.reader(
-                counting_file,
-                delimiter=self.config.separator,
-                skipinitialspace=True,
-                quoting=self.config.quoting,
-                escapechar=self.config.escapechar,
-            )
-            next(counting_reader)  # skip header row
-            self.entities_count = sum(1 for _ in counting_reader)
-        return self.entities_count
+        # Named pipes (FIFOs) and non-seekable streams cannot be pre-read without
+        # draining the pipe or causing deadlock with background writer threads.
+        try:
+            if stat.S_ISFIFO(os.stat(self.infile.name).st_mode):
+                self.entities_count = 0
+                return 0
+        except (OSError, ValueError, AttributeError):
+            pass
+
+        try:
+            # Open a separate file handle so self.reader's position and line_num
+            # are not disturbed.  Using csv.reader (rather than raw line iteration)
+            # ensures that fields containing embedded newlines (RFC 4180) are
+            # counted as a single row.
+            with io.open(self.infile.name, "rt", encoding="utf-8-sig") as counting_file:
+                counting_reader = csv.reader(
+                    counting_file,
+                    delimiter=self.config.separator,
+                    skipinitialspace=True,
+                    quoting=self.config.quoting,
+                    escapechar=self.config.escapechar,
+                )
+                next(counting_reader)  # skip header row
+                self.entities_count = sum(1 for _ in counting_reader)
+            return self.entities_count
+        except (OSError, io.UnsupportedOperation):
+            self.entities_count = 0
+            return 0
 
     # Simple input validations for each row of a CSV file
     def validate_row(self, row):

--- a/test/test_bulk_loader.py
+++ b/test/test_bulk_loader.py
@@ -937,3 +937,67 @@ class TestBulkLoader:
             [1, "Filipe", ["User"], 1, 40, ["Post"]],
         ]
         assert query_result.result_set == expected_result
+
+    def test_fifo_named_pipe_streaming(self):
+        """Validate that bulk insert can read from POSIX named pipes (FIFOs)."""
+        import tempfile
+        import threading
+
+        graphname = "fifo_stream_graph"
+        temp_dir = tempfile.mkdtemp(prefix="falkor_test_fifo_")
+        node_pipe = os.path.join(temp_dir, "nodes.fifo")
+        edge_pipe = os.path.join(temp_dir, "edges.fifo")
+
+        os.mkfifo(node_pipe)
+        os.mkfifo(edge_pipe)
+
+        def feed_nodes():
+            with open(node_pipe, "w", encoding="utf-8") as f:
+                f.write("id:ID,name:STRING\n")
+                f.write("u1,Alice\n")
+                f.write("u2,Bob\n")
+
+        def feed_edges():
+            with open(edge_pipe, "w", encoding="utf-8") as f:
+                f.write(":START_ID,:END_ID,role:STRING\n")
+                f.write("u1,u2,KNOWS\n")
+
+        t_nodes = threading.Thread(target=feed_nodes, daemon=True)
+        t_edges = threading.Thread(target=feed_edges, daemon=True)
+        t_nodes.start()
+        t_edges.start()
+
+        runner = CliRunner()
+        res = runner.invoke(
+            bulk_insert,
+            [
+                "--nodes-with-label",
+                "Person",
+                node_pipe,
+                "--relations-with-type",
+                "KNOWS",
+                edge_pipe,
+                "--enforce-schema",
+                graphname,
+            ],
+            catch_exceptions=False,
+        )
+
+        t_nodes.join(timeout=5.0)
+        t_edges.join(timeout=5.0)
+
+        # Cleanup FIFOs
+        for p in [node_pipe, edge_pipe]:
+            if os.path.exists(p):
+                os.remove(p)
+        if os.path.exists(temp_dir):
+            os.rmdir(temp_dir)
+
+        assert res.exit_code == 0
+        assert "2 nodes created" in res.output
+        assert "1 relations created" in res.output
+
+        graph = self.db_con.select_graph(graphname)
+        res = graph.query("MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN a.name, b.name")
+        assert res.result_set == [["Alice", "Bob"]]
+


### PR DESCRIPTION
### Summary
This PR adds support for reading from POSIX Named Pipes (FIFOs) and non-seekable streams in `falkordb-bulk-loader`.

### Problem
Previously, `EntityFile.count_entities()` attempted to open a secondary file handle to count rows prior to ingestion. When input files are Unix Named Pipes (FIFOs) or streams, opening a second handle or consuming the stream ahead of time leads to either `io.UnsupportedOperation: not seekable` or stream consumption / deadlock issues with writer threads.

### Solution
- Check if the file descriptor is a FIFO (`stat.S_ISFIFO`) or non-seekable stream before attempting a pre-pass count.
- If a FIFO is detected, bypass the counting step to allow pure single-pass forward streaming.
- Added unit test `test_fifo_named_pipe_streaming` in `test/test_bulk_loader.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk loading from named pipes and other non-seekable streams.
  * Prevented pipe-based imports from hanging or consuming input prematurely.
  * Improved handling of UTF-8 files with byte-order marks.
* **Tests**
  * Added coverage for importing nodes and relationships from named pipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->